### PR TITLE
fix(ci): unblock security scan workflow jobs

### DIFF
--- a/.github/workflows/security-scan-enhanced.yml
+++ b/.github/workflows/security-scan-enhanced.yml
@@ -415,9 +415,15 @@ jobs:
           
           if [ "${{ steps.parse-vulns.outputs.has_updates }}" == "true" ]; then
             echo "✅ **Updates Applied:**" >> $GITHUB_STEP_SUMMARY
-            [ "${{ steps.parse-vulns.outputs.has_alpine_updates }}" == "true" ] && echo "- Alpine packages updated" >> $GITHUB_STEP_SUMMARY
-            [ "${{ steps.parse-vulns.outputs.has_go_updates }}" == "true" ] && echo "- Go modules updated" >> $GITHUB_STEP_SUMMARY
-            [ "${{ steps.parse-vulns.outputs.has_npm_updates }}" == "true" ] && echo "- npm packages updated" >> $GITHUB_STEP_SUMMARY
+            if [ "${{ steps.parse-vulns.outputs.has_alpine_updates }}" == "true" ]; then
+              echo "- Alpine packages updated" >> $GITHUB_STEP_SUMMARY
+            fi
+            if [ "${{ steps.parse-vulns.outputs.has_go_updates }}" == "true" ]; then
+              echo "- Go modules updated" >> $GITHUB_STEP_SUMMARY
+            fi
+            if [ "${{ steps.parse-vulns.outputs.has_npm_updates }}" == "true" ]; then
+              echo "- npm packages updated" >> $GITHUB_STEP_SUMMARY
+            fi
           else
             echo "✅ No fixable vulnerabilities found" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -105,6 +105,7 @@ jobs:
 
       - name: Parse Trivy results and create issues (Backend)
         if: always()
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -257,6 +258,7 @@ jobs:
 
       - name: Parse Trivy results and create issues (Frontend)
         if: always()
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary\n- make Trivy issue-creation github-script steps non-blocking in security-scan workflow\n- fix Summary step in security-scan-enhanced to avoid bash -e failures on false guard expressions\n\n## Why\nPR #108 currently has two failing checks:\n- Security Scan/security-scan (push)\n- Security Scan Enhanced/security-scan-and-update (push)\n\nThese changes address those failure modes while keeping scan/upload behavior intact.