### PR TITLE
feat(ci): auto-label newly opened GitHub issues

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -5,7 +5,6 @@ on:
     types: [opened]
 
 permissions:
-  contents: read
   issues: write
 
 jobs:
@@ -125,13 +124,19 @@ jobs:
                 })
               } catch (error) {
                 if (error.status === 404) {
-                  await github.rest.issues.createLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name: labelDef.name,
-                    color: labelDef.color,
-                    description: labelDef.description
-                  })
+                  try {
+                    await github.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: labelDef.name,
+                      color: labelDef.color,
+                      description: labelDef.description
+                    })
+                  } catch (createError) {
+                    if (createError.status !== 422) {
+                      throw createError
+                    }
+                  }
                 } else {
                   throw error
                 }


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to automatically label newly opened issues
- infer labels from issue title/body keywords (bug, enhancement, documentation, security, performance, question)
- apply fallback 	riage label when no keyword matches
- auto-create missing labels before applying them

## Why
- speeds up triage and keeps issue queues organized without manual labeling

## Validation
- workflow file validates in VS Code diagnostics
- branch pushed and ready for CI checks