### PR TITLE
ci/docs: add strict-gated CALM validation and architecture review checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+- What changed:
+- Why:
+
+## Validation
+
+- [ ] `make calm-validate` (or `make calm-validate-warn` where appropriate)
+- [ ] Relevant tests/lint/build commands completed
+
+## Architecture as Code Checklist
+
+- [ ] If this PR changes authentication boundaries, messaging/event flows,
+  or persistence boundaries, I updated
+  [docs/architecture-as-code/models/axiom-core.architecture.json](docs/architecture-as-code/models/axiom-core.architecture.json)
+  in this PR.
+- [ ] If architecture boundaries changed, I verified consistency with
+  [docs/adr/adr-0015-architecture-as-code-calm-pilot.md](docs/adr/adr-0015-architecture-as-code-calm-pilot.md).
+
+## Linked Work
+
+- Issue(s):
+- ADR(s):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,22 @@ jobs:
       - name: Validate CALM models (warn mode)
         run: make calm-validate-warn
 
+  validate-architecture-as-code-strict:
+    name: Architecture as Code Validate (strict)
+    runs-on: ubuntu-latest
+    if: ${{ vars.CALM_VALIDATE_STRICT == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Validate CALM models (strict mode)
+        run: make calm-validate
+
   validate-migrations:
     name: Validate DB Migrations
     runs-on: ubuntu-latest
@@ -350,7 +366,7 @@ jobs:
   ci-summary:
     name: CI Summary (${{ needs.detect-environment.outputs.environment || 'none' }})
     runs-on: ubuntu-latest
-    needs: [detect-environment, lint-go, lint-docker, lint-docs, validate-architecture-as-code, lint-frontend, validate-migrations, build-go, test-go, build-frontend, build-docs-user]
+    needs: [detect-environment, lint-go, lint-docker, lint-docs, validate-architecture-as-code, validate-architecture-as-code-strict, lint-frontend, validate-migrations, build-go, test-go, build-frontend, build-docs-user]
     if: always()
     steps:
       - name: Report CI result
@@ -360,6 +376,7 @@ jobs:
           LINT_DOCKER="${{ needs.lint-docker.result }}"
           LINT_DOCS="${{ needs.lint-docs.result }}"
           CALM_VALIDATE="${{ needs.validate-architecture-as-code.result }}"
+          CALM_VALIDATE_STRICT="${{ needs.validate-architecture-as-code-strict.result }}"
           LINT_FRONTEND="${{ needs.lint-frontend.result }}"
           MIGRATIONS="${{ needs.validate-migrations.result }}"
           BUILD="${{ needs.build-go.result }}"
@@ -372,6 +389,7 @@ jobs:
           echo "Docker Lint     : $LINT_DOCKER"
           echo "Docs Lint       : $LINT_DOCS"
           echo "CALM Validate   : $CALM_VALIDATE"
+          echo "CALM Strict     : $CALM_VALIDATE_STRICT"
           echo "Frontend Lint   : $LINT_FRONTEND"
           echo "Migrations      : $MIGRATIONS"
           echo "Build           : $BUILD"
@@ -389,6 +407,11 @@ jobs:
              [ "$BUILD_FRONTEND" != "success" ] || \
              [ "$BUILD_DOCS_USER" != "success" ]; then
             echo "❌ CI failed — see individual job logs above."
+            exit 1
+          fi
+
+          if [ "${{ vars.CALM_VALIDATE_STRICT }}" = "true" ] && [ "$CALM_VALIDATE_STRICT" != "success" ]; then
+            echo "❌ CI failed — CALM strict validation is enabled and did not pass."
             exit 1
           fi
 

--- a/docs/architecture-as-code/README.md
+++ b/docs/architecture-as-code/README.md
@@ -38,7 +38,12 @@ See [pilot-scope.md](./pilot-scope.md) for boundaries and exclusions.
 
 - Local strict validation: `make calm-validate`
 - Local warn-only validation: `make calm-validate-warn`
-- CI currently runs warn mode while the pilot stabilizes.
+- CI runs warn mode by default while the pilot stabilizes.
+- Set repository variable `CALM_VALIDATE_STRICT=true` to enable strict blocking validation in CI.
+
+## Traceability
+
+- ADR-to-model traceability map: [adr-model-map.md](adr-model-map.md)
 
 ## Current Status
 

--- a/docs/architecture-as-code/adr-model-map.md
+++ b/docs/architecture-as-code/adr-model-map.md
@@ -1,0 +1,27 @@
+# ADR to CALM Model Mapping
+
+This mapping links architecture decisions to machine-readable CALM artifacts for review traceability.
+
+## Current Mapping
+
+- [ADR-0001: Modular Monolith](../adr/adr-0001-modular-monolith-architecture.md)
+  - CALM impact: system boundaries and core runtime nodes in [axiom-core.architecture.json](models/axiom-core.architecture.json)
+- [ADR-0004: JWT Authentication](../adr/adr-0004-jwt-authentication.md)
+  - CALM impact: authentication flow in [axiom-core.architecture.json](models/axiom-core.architecture.json) (`flow-authentication`)
+- [ADR-0005: RabbitMQ Async Processing](../adr/adr-0005-rabbitmq-async-processing.md)
+  - CALM impact: async relationship and LEI sync flow in
+    [axiom-core.architecture.json](models/axiom-core.architecture.json)
+    (`rel-api-rabbitmq`, `flow-lei-sync`)
+- [ADR-0015: Architecture as Code (CALM) Pilot Adoption](../adr/adr-0015-architecture-as-code-calm-pilot.md)
+  - CALM impact: source-of-truth policy and pilot scope captured by
+    [Architecture as Code overview](README.md),
+    [pilot scope](pilot-scope.md), and
+    [axiom-core.architecture.json](models/axiom-core.architecture.json)
+
+## Usage in PR Reviews
+
+When a PR changes architecture boundaries, reviewers should verify:
+
+1. Decision alignment: affected ADR references still match implementation intent.
+2. Model alignment: impacted flows/relationships are updated in CALM JSON.
+3. Documentation alignment: architecture narrative and model links remain current.

--- a/llms.txt
+++ b/llms.txt
@@ -26,6 +26,8 @@ WebSocket support, rate limiting, Prometheus metrics, and containerized deployme
   source-of-truth policy, and contributor workflow
 - [Architecture as Code Pilot Scope](docs/architecture-as-code/pilot-scope.md): v1 model boundaries,
   exclusions, and pilot success criteria
+- [ADR to CALM Model Mapping](docs/architecture-as-code/adr-model-map.md): Traceability between ADR decisions
+  and machine-readable architecture artifacts for PR review
 - [Changelog](CHANGELOG.md): Version history and notable changes
 
 ## User Documentation — Getting Started


### PR DESCRIPTION
## Summary
- Step 2: add a strict-gated CALM validation path in CI while preserving warn mode by default.
- Step 3: add ADR-to-model mapping for architecture traceability.
- Step 4: add lightweight PR checklist rules for architecture-boundary changes.

## What changed
- CI: added `validate-architecture-as-code-strict` job behind repository variable `CALM_VALIDATE_STRICT=true`.
- CI summary: reports strict result and fails only when strict mode is enabled and strict validation fails.
- PR process: added `.github/pull_request_template.md` with architecture-as-code checklist items.
- Docs: added `docs/architecture-as-code/adr-model-map.md` and linked it from `docs/architecture-as-code/README.md` and `llms.txt`.

## Validation
- `bash scripts/validate-calm.sh` (strict): passed
- `markdownlint --config .markdownlint.yaml .github/pull_request_template.md docs/architecture-as-code/README.md docs/architecture-as-code/adr-model-map.md llms.txt`: passed

## Tracking
- Related issue: #204 (reopened for this phase)