### PR TITLE
fix: clean and prevent Level 2 false-positive audit rows

### DIFF
--- a/backend/internal/repository/lei_level2_repository.go
+++ b/backend/internal/repository/lei_level2_repository.go
@@ -786,10 +786,17 @@ func (r *leiLevel2Repository) detectRRChanges(old, new *domain.LEIRelationshipRe
 		}
 	}
 
+	checkJSONB := func(field string, oldVal, newVal domain.JSONBString) {
+		if jsonBStringsSemanticEqual(oldVal, newVal) {
+			return
+		}
+		changes[field] = level2ChangeDetection{field, oldVal, newVal}
+	}
+
 	check("RelationshipStatus", old.RelationshipStatus, new.RelationshipStatus)
-	check("RelationshipPeriods", old.RelationshipPeriods, new.RelationshipPeriods)
-	check("RelationshipQualifiers", old.RelationshipQualifiers, new.RelationshipQualifiers)
-	check("RelationshipQuantifiers", old.RelationshipQuantifiers, new.RelationshipQuantifiers)
+	checkJSONB("RelationshipPeriods", old.RelationshipPeriods, new.RelationshipPeriods)
+	checkJSONB("RelationshipQualifiers", old.RelationshipQualifiers, new.RelationshipQualifiers)
+	checkJSONB("RelationshipQuantifiers", old.RelationshipQuantifiers, new.RelationshipQuantifiers)
 	check("RegistrationStatus", old.RegistrationStatus, new.RegistrationStatus)
 	checkTime("InitialRegistrationDate", old.InitialRegistrationDate, new.InitialRegistrationDate)
 	checkTime("LastUpdateDate", old.LastUpdateDate, new.LastUpdateDate)
@@ -798,7 +805,6 @@ func (r *leiLevel2Repository) detectRRChanges(old, new *domain.LEIRelationshipRe
 	check("ValidationSources", old.ValidationSources, new.ValidationSources)
 	check("ValidationDocuments", old.ValidationDocuments, new.ValidationDocuments)
 	check("ValidationReference", old.ValidationReference, new.ValidationReference)
-	check("SourceFileID", old.SourceFileID, new.SourceFileID)
 
 	return changes
 }
@@ -815,17 +821,6 @@ func (r *leiLevel2Repository) detectRepexChanges(old, new *domain.LEIReportingEx
 
 	check("ExceptionReason", old.ExceptionReason, new.ExceptionReason)
 	check("ExceptionReference", old.ExceptionReference, new.ExceptionReference)
-
-	// Detect source file change using the same check pattern as string fields.
-	oldSrc := ""
-	if old.SourceFileID != nil {
-		oldSrc = old.SourceFileID.String()
-	}
-	newSrc := ""
-	if new.SourceFileID != nil {
-		newSrc = new.SourceFileID.String()
-	}
-	check("SourceFileID", oldSrc, newSrc)
 
 	return changes
 }

--- a/backend/internal/repository/lei_level2_repository_test.go
+++ b/backend/internal/repository/lei_level2_repository_test.go
@@ -73,6 +73,22 @@ func TestDetectRRChangesDetectsJSONBFieldChange(t *testing.T) {
 	}
 }
 
+func TestDetectRRChangesIgnoresJSONKeyOrdering(t *testing.T) {
+	t.Helper()
+
+	old := &domain.LEIRelationshipRecord{
+		RelationshipPeriods: domain.JSONBString(`[{"startDate":"2020-01-01","endDate":"2021-01-01"}]`),
+	}
+	new := &domain.LEIRelationshipRecord{
+		RelationshipPeriods: domain.JSONBString(`[{"endDate":"2021-01-01","startDate":"2020-01-01"}]`),
+	}
+
+	changes := level2Repo.detectRRChanges(old, new)
+	if _, ok := changes["RelationshipPeriods"]; ok {
+		t.Fatalf("expected JSON key ordering differences to be ignored")
+	}
+}
+
 func TestDetectRRChangesAllThreeJSONBFieldsChecked(t *testing.T) {
 	t.Helper()
 
@@ -136,7 +152,7 @@ func TestDetectRRChangesBothNilTimesProducesNoChange(t *testing.T) {
 	}
 }
 
-func TestDetectRRChangesDetectsSourceFileIDChange(t *testing.T) {
+func TestDetectRRChangesIgnoresSourceFileIDChange(t *testing.T) {
 	t.Helper()
 
 	id1 := uuid.New()
@@ -146,8 +162,8 @@ func TestDetectRRChangesDetectsSourceFileIDChange(t *testing.T) {
 	new := &domain.LEIRelationshipRecord{SourceFileID: &id2}
 
 	changes := level2Repo.detectRRChanges(old, new)
-	if _, ok := changes["SourceFileID"]; !ok {
-		t.Fatalf("expected SourceFileID to be detected as changed")
+	if _, ok := changes["SourceFileID"]; ok {
+		t.Fatalf("expected SourceFileID change to be ignored")
 	}
 }
 
@@ -220,7 +236,7 @@ func TestDetectRepexChangesDetectsExceptionReferenceChange(t *testing.T) {
 	}
 }
 
-func TestDetectRepexChangesDetectsSourceFileIDChange(t *testing.T) {
+func TestDetectRepexChangesIgnoresSourceFileIDChange(t *testing.T) {
 	t.Helper()
 
 	id1 := uuid.New()
@@ -230,12 +246,12 @@ func TestDetectRepexChangesDetectsSourceFileIDChange(t *testing.T) {
 	new := &domain.LEIReportingException{SourceFileID: &id2}
 
 	changes := level2Repo.detectRepexChanges(old, new)
-	if _, ok := changes["SourceFileID"]; !ok {
-		t.Fatalf("expected SourceFileID to be detected as changed")
+	if _, ok := changes["SourceFileID"]; ok {
+		t.Fatalf("expected SourceFileID change to be ignored")
 	}
 }
 
-func TestDetectRepexChangesNilToNonNilSourceFileIDIsDetected(t *testing.T) {
+func TestDetectRepexChangesNilToNonNilSourceFileIDIsIgnored(t *testing.T) {
 	t.Helper()
 
 	id := uuid.New()
@@ -243,8 +259,8 @@ func TestDetectRepexChangesNilToNonNilSourceFileIDIsDetected(t *testing.T) {
 	new := &domain.LEIReportingException{SourceFileID: &id}
 
 	changes := level2Repo.detectRepexChanges(old, new)
-	if _, ok := changes["SourceFileID"]; !ok {
-		t.Fatalf("expected nil→non-nil SourceFileID to be detected as changed")
+	if _, ok := changes["SourceFileID"]; ok {
+		t.Fatalf("expected nil→non-nil SourceFileID to be ignored")
 	}
 }
 
@@ -263,28 +279,23 @@ func TestDetectRepexChangesBothNilSourceFileIDProducesNoChange(t *testing.T) {
 func TestDetectRepexChangesAllFieldsChecked(t *testing.T) {
 	t.Helper()
 
-	id1 := uuid.New()
-	id2 := uuid.New()
-
 	old := &domain.LEIReportingException{
 		ExceptionReason:    "NO_KNOWN_PERSON",
 		ExceptionReference: "ref1",
-		SourceFileID:       &id1,
 	}
 	new := &domain.LEIReportingException{
 		ExceptionReason:    "NATURAL_PERSONS",
 		ExceptionReference: "ref2",
-		SourceFileID:       &id2,
 	}
 
 	changes := level2Repo.detectRepexChanges(old, new)
-	for _, field := range []string{"ExceptionReason", "ExceptionReference", "SourceFileID"} {
+	for _, field := range []string{"ExceptionReason", "ExceptionReference"} {
 		if _, ok := changes[field]; !ok {
 			t.Fatalf("expected %s to be detected as changed", field)
 		}
 	}
-	if len(changes) != 3 {
-		t.Fatalf("expected exactly 3 changed fields, got %d: %v", len(changes), changes)
+	if len(changes) != 2 {
+		t.Fatalf("expected exactly 2 changed fields, got %d: %v", len(changes), changes)
 	}
 }
 

--- a/backend/migrations/000052_remove_false_positive_level2_audit_rows.down.sql
+++ b/backend/migrations/000052_remove_false_positive_level2_audit_rows.down.sql
@@ -1,0 +1,3 @@
+-- No undo: deleted audit rows cannot be recreated.
+-- This migration permanently removes false-positive UPDATE audit rows from Level 2 tables.
+SELECT 1;

--- a/backend/migrations/000052_remove_false_positive_level2_audit_rows.up.sql
+++ b/backend/migrations/000052_remove_false_positive_level2_audit_rows.up.sql
@@ -1,0 +1,151 @@
+-- Remove false-positive UPDATE audit rows from Level 2 LEI audit tables.
+--
+-- Scope:
+--   * lei_raw.lei_relationship_records_audit
+--   * lei_raw.lei_reporting_exceptions_audit
+--
+-- This migration removes changed_fields entries that are not semantic data changes:
+--   1) entries where new_value == old_value (JSONB semantic equality), and
+--   2) source-file provenance-only entries (SourceFileID / source_file_id).
+--
+-- After stripping these entries, UPDATE audit rows with no meaningful changes left
+-- are deleted.
+--
+-- Like 000048, work is done in batches to reduce per-statement runtime and WAL spikes.
+
+DO $$
+DECLARE
+    _batch_size CONSTANT INTEGER := 10000;
+    _rows_done INTEGER;
+    _total INTEGER;
+    _batch_no INTEGER;
+    _last_id UUID;
+    _next_last_id UUID;
+    _table_name TEXT;
+BEGIN
+    FOREACH _table_name IN ARRAY ARRAY[
+        'lei_raw.lei_relationship_records_audit',
+        'lei_raw.lei_reporting_exceptions_audit'
+    ]
+    LOOP
+        -- Step 1: remove false-positive/non-semantic entries from changed_fields.
+        _total := 0;
+        _batch_no := 0;
+        _last_id := '00000000-0000-0000-0000-000000000000';
+
+        LOOP
+            EXECUTE format(
+                $SQL$
+                WITH to_fix AS (
+                    SELECT id
+                    FROM %s
+                    WHERE "action" = 'UPDATE'
+                    AND id > $1
+                    AND changed_fields IS NOT NULL
+                    AND changed_fields::TEXT <> '{}'
+                    AND EXISTS (
+                        SELECT 1
+                        FROM JSONB_EACH(changed_fields) AS fld (field_key, field_val)
+                        WHERE LOWER(fld.field_key) IN ('sourcefileid', 'source_file_id')
+                        OR (fld.field_val -> 'new_value') IS NOT DISTINCT FROM (fld.field_val -> 'old_value')
+                    )
+                    ORDER BY id
+                    LIMIT $2
+                ),
+                updated AS (
+                    UPDATE %s AS a
+                    SET changed_fields = (
+                        SELECT JSONB_OBJECT_AGG(fld.field_key, fld.field_val)
+                        FROM JSONB_EACH(a.changed_fields) AS fld (field_key, field_val)
+                        WHERE LOWER(fld.field_key) NOT IN ('sourcefileid', 'source_file_id')
+                        AND (fld.field_val -> 'new_value') IS DISTINCT FROM (fld.field_val -> 'old_value')
+                    )
+                    FROM to_fix
+                    WHERE a.id = to_fix.id
+                    RETURNING a.id
+                )
+                SELECT
+                    COUNT(*),
+                    COALESCE((ARRAY_AGG(id ORDER BY id DESC))[1], $1)
+                FROM updated
+                $SQL$,
+                _table_name,
+                _table_name
+            )
+            INTO _rows_done, _next_last_id
+            USING _last_id, _batch_size;
+
+            _total := _total + _rows_done;
+            _last_id := _next_last_id;
+
+            EXIT WHEN _rows_done = 0;
+
+            _batch_no := _batch_no + 1;
+            RAISE NOTICE 'Level 2 Step 1 batch % for %: % rows updated (running total: %, last_id: %)',
+                _batch_no,
+                _table_name,
+                _rows_done,
+                _total,
+                _last_id;
+        END LOOP;
+
+        RAISE NOTICE 'Level 2 Step 1 complete for %: % rows updated', _table_name, _total;
+
+        -- Step 2: remove UPDATE rows that have no meaningful changed_fields entries.
+        _total := 0;
+        _batch_no := 0;
+        _last_id := '00000000-0000-0000-0000-000000000000';
+
+        LOOP
+            EXECUTE format(
+                $SQL$
+                WITH to_delete AS (
+                    SELECT a.id
+                    FROM %s AS a
+                    WHERE a."action" = 'UPDATE'
+                    AND a.id > $1
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM JSONB_EACH(a.changed_fields) AS fld (field_key, field_val)
+                        WHERE LOWER(fld.field_key) NOT IN ('sourcefileid', 'source_file_id')
+                        AND (fld.field_val -> 'new_value') IS DISTINCT FROM (fld.field_val -> 'old_value')
+                    )
+                    ORDER BY a.id
+                    LIMIT $2
+                ),
+                deleted AS (
+                    DELETE FROM %s
+                    USING to_delete
+                    WHERE %s.id = to_delete.id
+                    RETURNING %s.id
+                )
+                SELECT
+                    COUNT(*),
+                    COALESCE((ARRAY_AGG(id ORDER BY id DESC))[1], $1)
+                FROM deleted
+                $SQL$,
+                _table_name,
+                _table_name,
+                _table_name,
+                _table_name
+            )
+            INTO _rows_done, _next_last_id
+            USING _last_id, _batch_size;
+
+            _total := _total + _rows_done;
+            _last_id := _next_last_id;
+
+            EXIT WHEN _rows_done = 0;
+
+            _batch_no := _batch_no + 1;
+            RAISE NOTICE 'Level 2 Step 2 batch % for %: % rows deleted (running total: %, last_id: %)',
+                _batch_no,
+                _table_name,
+                _rows_done,
+                _total,
+                _last_id;
+        END LOOP;
+
+        RAISE NOTICE 'Level 2 Step 2 complete for %: % rows deleted', _table_name, _total;
+    END LOOP;
+END $$;


### PR DESCRIPTION
## Summary

This PR addresses false-positive Level 2 LEI audit UPDATE rows and prevents recurrence.

### Changes made

- Added migration to clean existing false-positive rows:
  - `backend/migrations/000052_remove_false_positive_level2_audit_rows.up.sql`
  - `backend/migrations/000052_remove_false_positive_level2_audit_rows.down.sql`
- Updated Level 2 change detection to avoid provenance-only audit noise:
  - `backend/internal/repository/lei_level2_repository.go`
- Added/updated tests covering the new behavior:
  - `backend/internal/repository/lei_level2_repository_test.go`

## What the migration does

For both `lei_raw.lei_relationship_records_audit` and `lei_raw.lei_reporting_exceptions_audit`:

1. Removes `changed_fields` entries where:
   - `new_value == old_value` (semantic no-op), or
   - field key is `SourceFileID` / `source_file_id`
2. Deletes UPDATE audit rows that have no meaningful changes remaining.
3. Processes in 10k batches and emits `RAISE NOTICE` progress per batch.

## Preventive logic fix

- Stop treating `SourceFileID` changes as business-field changes in Level 2 diff detection.
- Use semantic JSON comparison for Level 2 relationship JSONB fields to avoid key-order false positives.

## Validation

- `runTests` on `backend/internal/repository/lei_level2_repository_test.go`
  - Passed: 35
  - Failed: 0
- One-batch live DB simulation in `axiom_main` (in transaction with rollback) confirmed expected behavior.

## Notes

- This PR intentionally contains only the audit fix/migration scope.