### PR TITLE
feat: store all valid GLEIF multilingual variants

### DIFF
--- a/backend/internal/domain/lei_reference_models.go
+++ b/backend/internal/domain/lei_reference_models.go
@@ -57,19 +57,19 @@ func (GLEIFEntityLegalForm) TableName() string {
 // Source: GLEIF organizational roles code list (CSV).
 // Resolves role codes in LEI Level 2 data to human-readable role names.
 type GLEIFOrganizationalRole struct {
-	ID                     uuid.UUID `gorm:"type:uuid;primary_key;default:gen_random_uuid()" json:"id"`
-	RoleCode               string    `gorm:"column:role_code;size:50;not null" json:"role_code"`
-	RoleName               string    `gorm:"size:500;not null" json:"role_name"`
-	Description            string    `gorm:"type:text" json:"description"`
-	LanguageCode           string    `gorm:"size:10;not null;default:''" json:"language_code"`
-	ELFCode                string    `gorm:"column:elf_code;size:10;not null;default:''" json:"elf_code"`
-	CountryCode            string    `gorm:"column:country_of_formation;size:2;not null;default:''" json:"country_of_formation"`
-	CountrySubdivisionCode string    `gorm:"column:country_subdivision_of_formation;size:10;not null;default:''" json:"country_subdivision_of_formation"`
-	Active                 bool      `gorm:"default:true" json:"active"`
-	CreatedBy              string    `gorm:"size:100;not null;default:'system'" json:"created_by"`
-	UpdatedBy              string    `gorm:"size:100;not null;default:'system'" json:"updated_by"`
-	CreatedAt              time.Time `json:"created_at"`
-	UpdatedAt              time.Time `json:"updated_at"`
+	ID                            uuid.UUID `gorm:"type:uuid;primary_key;default:gen_random_uuid()" json:"id"`
+	RoleCode                      string    `gorm:"column:role_code;size:50;not null" json:"role_code"`
+	RoleName                      string    `gorm:"size:500;not null" json:"role_name"`
+	Description                   string    `gorm:"type:text" json:"description"`
+	LanguageCode                  string    `gorm:"size:10;not null;default:''" json:"language_code"`
+	ELFCode                       string    `gorm:"column:elf_code;size:10;not null;default:''" json:"elf_code"`
+	CountryOfFormation            string    `gorm:"column:country_of_formation;size:2;not null;default:''" json:"country_of_formation"`
+	CountrySubdivisionOfFormation string    `gorm:"column:country_subdivision_of_formation;size:10;not null;default:''" json:"country_subdivision_of_formation"`
+	Active                        bool      `gorm:"default:true" json:"active"`
+	CreatedBy                     string    `gorm:"size:100;not null;default:'system'" json:"created_by"`
+	UpdatedBy                     string    `gorm:"size:100;not null;default:'system'" json:"updated_by"`
+	CreatedAt                     time.Time `json:"created_at"`
+	UpdatedAt                     time.Time `json:"updated_at"`
 }
 
 // TableName sets the GORM table name.

--- a/backend/internal/domain/lei_reference_models.go
+++ b/backend/internal/domain/lei_reference_models.go
@@ -10,19 +10,19 @@ import (
 // Source: GLEIF Registration Authorities List (CSV).
 // Resolves registration_authority codes in LEI records to human-readable names.
 type GLEIFRegistrationAuthority struct {
-	ID                  uuid.UUID `gorm:"type:uuid;primary_key;default:gen_random_uuid()" json:"id"`
-	RAID                string    `gorm:"column:ra_id;uniqueIndex;size:50;not null" json:"ra_id"`
-	OrganizationName    string    `gorm:"size:500;not null" json:"organization_name"`
-	Jurisdiction        string    `gorm:"size:100" json:"jurisdiction"`
-	InternationalName   string    `gorm:"size:500" json:"international_name"`
-	LanguagesUsed       string    `gorm:"size:100" json:"languages_used"`
-	Website             string    `gorm:"size:500" json:"website"`
-	Comments            string    `gorm:"type:text" json:"comments"`
-	Active              bool      `gorm:"default:true" json:"active"`
-	CreatedBy           string    `gorm:"size:100;not null;default:'system'" json:"created_by"`
-	UpdatedBy           string    `gorm:"size:100;not null;default:'system'" json:"updated_by"`
-	CreatedAt           time.Time `json:"created_at"`
-	UpdatedAt           time.Time `json:"updated_at"`
+	ID                uuid.UUID `gorm:"type:uuid;primary_key;default:gen_random_uuid()" json:"id"`
+	RAID              string    `gorm:"column:ra_id;uniqueIndex;size:50;not null" json:"ra_id"`
+	OrganizationName  string    `gorm:"size:500;not null" json:"organization_name"`
+	Jurisdiction      string    `gorm:"size:100" json:"jurisdiction"`
+	InternationalName string    `gorm:"size:500" json:"international_name"`
+	LanguagesUsed     string    `gorm:"size:100" json:"languages_used"`
+	Website           string    `gorm:"size:500" json:"website"`
+	Comments          string    `gorm:"type:text" json:"comments"`
+	Active            bool      `gorm:"default:true" json:"active"`
+	CreatedBy         string    `gorm:"size:100;not null;default:'system'" json:"created_by"`
+	UpdatedBy         string    `gorm:"size:100;not null;default:'system'" json:"updated_by"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
 }
 
 // TableName sets the GORM table name.
@@ -34,17 +34,18 @@ func (GLEIFRegistrationAuthority) TableName() string {
 // Source: GLEIF ELF code list (CSV).
 // Resolves entity_legal_form codes in LEI records to human-readable names.
 type GLEIFEntityLegalForm struct {
-	ID                               uuid.UUID `gorm:"type:uuid;primary_key;default:gen_random_uuid()" json:"id"`
-	ELFCode                          string    `gorm:"column:elf_code;uniqueIndex;size:10;not null" json:"elf_code"`
-	EntityLegalFormName              string    `gorm:"size:500;not null" json:"entity_legal_form_name"`
-	Abbreviations                    string    `gorm:"size:100" json:"abbreviations"`
-	CountryOfFormation               string    `gorm:"size:2" json:"country_of_formation"`
-	CountrySubdivisionOfFormation    string    `gorm:"size:10" json:"country_subdivision_of_formation"`
-	Status                           string    `gorm:"size:20;not null;default:'ACTIVE'" json:"status"`
-	CreatedBy                        string    `gorm:"size:100;not null;default:'system'" json:"created_by"`
-	UpdatedBy                        string    `gorm:"size:100;not null;default:'system'" json:"updated_by"`
-	CreatedAt                        time.Time `json:"created_at"`
-	UpdatedAt                        time.Time `json:"updated_at"`
+	ID                            uuid.UUID `gorm:"type:uuid;primary_key;default:gen_random_uuid()" json:"id"`
+	ELFCode                       string    `gorm:"column:elf_code;size:10;not null" json:"elf_code"`
+	EntityLegalFormName           string    `gorm:"size:500;not null" json:"entity_legal_form_name"`
+	Abbreviations                 string    `gorm:"size:100" json:"abbreviations"`
+	LanguageCode                  string    `gorm:"size:10;not null;default:''" json:"language_code"`
+	CountryOfFormation            string    `gorm:"size:2;not null;default:''" json:"country_of_formation"`
+	CountrySubdivisionOfFormation string    `gorm:"size:10;not null;default:''" json:"country_subdivision_of_formation"`
+	Status                        string    `gorm:"size:20;not null;default:'ACTIVE'" json:"status"`
+	CreatedBy                     string    `gorm:"size:100;not null;default:'system'" json:"created_by"`
+	UpdatedBy                     string    `gorm:"size:100;not null;default:'system'" json:"updated_by"`
+	CreatedAt                     time.Time `json:"created_at"`
+	UpdatedAt                     time.Time `json:"updated_at"`
 }
 
 // TableName sets the GORM table name.
@@ -56,15 +57,19 @@ func (GLEIFEntityLegalForm) TableName() string {
 // Source: GLEIF organizational roles code list (CSV).
 // Resolves role codes in LEI Level 2 data to human-readable role names.
 type GLEIFOrganizationalRole struct {
-	ID          uuid.UUID `gorm:"type:uuid;primary_key;default:gen_random_uuid()" json:"id"`
-	RoleCode    string    `gorm:"column:role_code;uniqueIndex;size:50;not null" json:"role_code"`
-	RoleName    string    `gorm:"size:500;not null" json:"role_name"`
-	Description string    `gorm:"type:text" json:"description"`
-	Active      bool      `gorm:"default:true" json:"active"`
-	CreatedBy   string    `gorm:"size:100;not null;default:'system'" json:"created_by"`
-	UpdatedBy   string    `gorm:"size:100;not null;default:'system'" json:"updated_by"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID                     uuid.UUID `gorm:"type:uuid;primary_key;default:gen_random_uuid()" json:"id"`
+	RoleCode               string    `gorm:"column:role_code;size:50;not null" json:"role_code"`
+	RoleName               string    `gorm:"size:500;not null" json:"role_name"`
+	Description            string    `gorm:"type:text" json:"description"`
+	LanguageCode           string    `gorm:"size:10;not null;default:''" json:"language_code"`
+	ELFCode                string    `gorm:"column:elf_code;size:10;not null;default:''" json:"elf_code"`
+	CountryCode            string    `gorm:"column:country_of_formation;size:2;not null;default:''" json:"country_of_formation"`
+	CountrySubdivisionCode string    `gorm:"column:country_subdivision_of_formation;size:10;not null;default:''" json:"country_subdivision_of_formation"`
+	Active                 bool      `gorm:"default:true" json:"active"`
+	CreatedBy              string    `gorm:"size:100;not null;default:'system'" json:"created_by"`
+	UpdatedBy              string    `gorm:"size:100;not null;default:'system'" json:"updated_by"`
+	CreatedAt              time.Time `json:"created_at"`
+	UpdatedAt              time.Time `json:"updated_at"`
 }
 
 // TableName sets the GORM table name.

--- a/backend/internal/repository/gleif_reference_repository.go
+++ b/backend/internal/repository/gleif_reference_repository.go
@@ -89,10 +89,16 @@ func (r *gleifEntityLegalFormRepository) Upsert(records []*domain.GLEIFEntityLeg
 		return nil
 	}
 	return r.db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "elf_code"}},
+		Columns: []clause.Column{
+			{Name: "elf_code"},
+			{Name: "language_code"},
+			{Name: "country_of_formation"},
+			{Name: "country_subdivision_of_formation"},
+			{Name: "entity_legal_form_name"},
+			{Name: "status"},
+		},
 		DoUpdates: clause.AssignmentColumns([]string{
-			"entity_legal_form_name", "abbreviations", "country_of_formation",
-			"country_subdivision_of_formation", "status", "updated_by", "updated_at",
+			"abbreviations", "updated_by", "updated_at",
 		}),
 	}).Create(records).Error
 }
@@ -149,9 +155,16 @@ func (r *gleifOrganizationalRoleRepository) Upsert(records []*domain.GLEIFOrgani
 		return nil
 	}
 	return r.db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "role_code"}},
+		Columns: []clause.Column{
+			{Name: "role_code"},
+			{Name: "language_code"},
+			{Name: "country_of_formation"},
+			{Name: "country_subdivision_of_formation"},
+			{Name: "elf_code"},
+			{Name: "role_name"},
+		},
 		DoUpdates: clause.AssignmentColumns([]string{
-			"role_name", "description", "active", "updated_by", "updated_at",
+			"description", "active", "updated_by", "updated_at",
 		}),
 	}).Create(records).Error
 }

--- a/backend/internal/repository/lei_repository.go
+++ b/backend/internal/repository/lei_repository.go
@@ -78,7 +78,8 @@ const singleRecordResolvedNamesSelectFragment = "" +
 	", (SELECT ra.comments FROM lei_raw.gleif_registration_authorities ra" +
 	"   WHERE ra.ra_id = lei_raw.lei_records.registration_authority AND ra.active = TRUE LIMIT 1) AS registration_authority_comments" +
 	", (SELECT elf.entity_legal_form_name FROM lei_raw.gleif_entity_legal_forms elf" +
-	"   WHERE elf.elf_code = lei_raw.lei_records.entity_legal_form LIMIT 1) AS entity_legal_form_name"
+	"   WHERE elf.elf_code = lei_raw.lei_records.entity_legal_form" +
+	"   ORDER BY CASE WHEN COALESCE(elf.language_code, '') = 'en' THEN 0 ELSE 1 END, elf.updated_at DESC LIMIT 1) AS entity_legal_form_name"
 
 // exactLEIMatchWhereClause matches a record by its primary LEI or its successor LEI.
 // The successor branch includes the partial-index predicate so PostgreSQL can use
@@ -539,8 +540,9 @@ func (r *leiRepository) hydrateELFNames(records []*domain.LEIRecord) error {
 	var rows []elfNameRow
 	if err := r.db.
 		Table("lei_raw.gleif_entity_legal_forms").
-		Select("elf_code, entity_legal_form_name").
+		Select("DISTINCT ON (elf_code) elf_code, entity_legal_form_name").
 		Where("elf_code IN ?", codes).
+		Order("elf_code, CASE WHEN COALESCE(language_code, '') = 'en' THEN 0 ELSE 1 END, updated_at DESC").
 		Find(&rows).Error; err != nil {
 		return err
 	}

--- a/backend/internal/repository/lei_repository.go
+++ b/backend/internal/repository/lei_repository.go
@@ -79,7 +79,9 @@ const singleRecordResolvedNamesSelectFragment = "" +
 	"   WHERE ra.ra_id = lei_raw.lei_records.registration_authority AND ra.active = TRUE LIMIT 1) AS registration_authority_comments" +
 	", (SELECT elf.entity_legal_form_name FROM lei_raw.gleif_entity_legal_forms elf" +
 	"   WHERE elf.elf_code = lei_raw.lei_records.entity_legal_form" +
-	"   ORDER BY CASE WHEN COALESCE(elf.language_code, '') = 'en' THEN 0 ELSE 1 END, elf.updated_at DESC LIMIT 1) AS entity_legal_form_name"
+	"   ORDER BY CASE WHEN UPPER(BTRIM(COALESCE(elf.status, ''))) = 'ACTIVE' THEN 0 ELSE 1 END," +
+	"            CASE WHEN LOWER(COALESCE(elf.language_code, '')) = 'en' THEN 0 ELSE 1 END," +
+	"            elf.updated_at DESC LIMIT 1) AS entity_legal_form_name"
 
 // exactLEIMatchWhereClause matches a record by its primary LEI or its successor LEI.
 // The successor branch includes the partial-index predicate so PostgreSQL can use
@@ -542,7 +544,7 @@ func (r *leiRepository) hydrateELFNames(records []*domain.LEIRecord) error {
 		Table("lei_raw.gleif_entity_legal_forms").
 		Select("DISTINCT ON (elf_code) elf_code, entity_legal_form_name").
 		Where("elf_code IN ?", codes).
-		Order("elf_code, CASE WHEN COALESCE(language_code, '') = 'en' THEN 0 ELSE 1 END, updated_at DESC").
+		Order("elf_code, CASE WHEN COALESCE(status, '') = 'ACTIVE' THEN 0 ELSE 1 END, CASE WHEN COALESCE(language_code, '') = 'en' THEN 0 ELSE 1 END, updated_at DESC").
 		Find(&rows).Error; err != nil {
 		return err
 	}

--- a/backend/internal/repository/lei_repository_filter_test.go
+++ b/backend/internal/repository/lei_repository_filter_test.go
@@ -357,6 +357,9 @@ func TestHydrateELFNames_UsesSingleInQueryForDistinctCodes(t *testing.T) {
 	if !strings.Contains(sql, "elf_code in (?,?)") {
 		t.Fatalf("expected deduplicated IN query with 2 args, got: %s", sql)
 	}
+	if !strings.Contains(sql, "distinct on (elf_code)") {
+		t.Fatalf("expected deterministic DISTINCT ON selection for duplicate ELF variants, got: %s", sql)
+	}
 }
 
 func TestApplyELFNames_PopulatesHydratedFields(t *testing.T) {

--- a/backend/internal/repository/lei_repository_filter_test.go
+++ b/backend/internal/repository/lei_repository_filter_test.go
@@ -360,6 +360,9 @@ func TestHydrateELFNames_UsesSingleInQueryForDistinctCodes(t *testing.T) {
 	if !strings.Contains(sql, "distinct on (elf_code)") {
 		t.Fatalf("expected deterministic DISTINCT ON selection for duplicate ELF variants, got: %s", sql)
 	}
+	if !strings.Contains(sql, "case when coalesce(status, '') = 'active' then 0 else 1 end") {
+		t.Fatalf("expected ACTIVE-first ordering for duplicate ELF variants, got: %s", sql)
+	}
 }
 
 func TestApplyELFNames_PopulatesHydratedFields(t *testing.T) {

--- a/backend/internal/service/gleif_reference_service.go
+++ b/backend/internal/service/gleif_reference_service.go
@@ -348,6 +348,7 @@ func parseEntityLegalFormsCSV(r io.ReadCloser) ([]*domain.GLEIFEntityLegalForm, 
 			continue
 		}
 		status := strings.TrimSpace(safeCol(row, 12))
+		languageCode := strings.ToLower(strings.TrimSpace(safeCol(row, 7)))
 		countryOfFormation := safeCol(row, 1)
 		countrySubdivision := safeCol(row, 2)
 		name := safeCol(row, 3)
@@ -356,8 +357,8 @@ func parseEntityLegalFormsCSV(r io.ReadCloser) ([]*domain.GLEIFEntityLegalForm, 
 		if len(row) >= 13 {
 			countryOfFormation = firstNonEmpty(safeCol(row, 2), safeCol(row, 1))
 			countrySubdivision = firstNonEmpty(safeCol(row, 4), safeCol(row, 2))
-			name = firstNonEmpty(safeCol(row, 5), safeCol(row, 8), safeCol(row, 3))
-			abbrev = firstNonEmpty(safeCol(row, 9), safeCol(row, 10), safeCol(row, 4))
+			name = firstNonEmpty(safeCol(row, 8), safeCol(row, 5), safeCol(row, 3))
+			abbrev = firstNonEmpty(safeCol(row, 10), safeCol(row, 9), safeCol(row, 4))
 		}
 
 		if len(row) < 13 {
@@ -376,6 +377,7 @@ func parseEntityLegalFormsCSV(r io.ReadCloser) ([]*domain.GLEIFEntityLegalForm, 
 			ELFCode:                       truncateString(strings.ToUpper(elfCode), 10),
 			EntityLegalFormName:           truncateString(name, 500),
 			Abbreviations:                 truncateString(abbrev, 100),
+			LanguageCode:                  truncateString(languageCode, 10),
 			CountryOfFormation:            truncateString(strings.ToUpper(countryOfFormation), 2),
 			CountrySubdivisionOfFormation: truncateString(strings.ToUpper(countrySubdivision), 10),
 			Status:                        truncateString(strings.ToUpper(status), 20),
@@ -415,12 +417,23 @@ func parseOrganizationalRolesCSV(r io.ReadCloser) ([]*domain.GLEIFOrganizational
 		if roleCode == "" {
 			continue
 		}
+
+		languageCode := strings.ToLower(strings.TrimSpace(safeCol(row, 9)))
+		description := safeCol(row, 2)
+		if len(row) >= 19 {
+			description = firstNonEmpty(safeCol(row, 18), safeCol(row, 17))
+		}
+
 		records = append(records, &domain.GLEIFOrganizationalRole{
-			RoleCode:    truncateString(strings.ToUpper(roleCode), 50),
-			RoleName:    truncateString(firstNonEmpty(safeCol(row, 7), safeCol(row, 1)), 500),
-			Description: firstNonEmpty(safeCol(row, 18), safeCol(row, 2)),
-			Active:      true,
-			UpdatedBy:   "gleif_sync",
+			RoleCode:               truncateString(strings.ToUpper(roleCode), 50),
+			RoleName:               truncateString(firstNonEmpty(safeCol(row, 10), safeCol(row, 7), safeCol(row, 1)), 500),
+			Description:            description,
+			LanguageCode:           truncateString(languageCode, 10),
+			ELFCode:                truncateString(strings.ToUpper(strings.TrimSpace(safeCol(row, 6))), 10),
+			CountryCode:            truncateString(strings.ToUpper(strings.TrimSpace(safeCol(row, 2))), 2),
+			CountrySubdivisionCode: truncateString(strings.ToUpper(strings.TrimSpace(safeCol(row, 4))), 10),
+			Active:                 true,
+			UpdatedBy:              "gleif_sync",
 		})
 	}
 	return records, nil
@@ -596,7 +609,7 @@ func (s *gleifReferenceService) SyncEntityLegalForms() error {
 	}
 	records, dropped, dupCodes := dedupeEntityLegalForms(records)
 	if dropped > 0 {
-		log.Warn().Int("dropped_duplicates", dropped).Strs("duplicate_codes", dupCodes).Msg("Dropped duplicate entity legal form codes before upsert")
+		log.Info().Int("collapsed_rows", dropped).Int("affected_codes", len(dupCodes)).Strs("sample_codes", sampleKeys(dupCodes, 25)).Msg("Collapsed exact duplicate entity legal form rows before upsert")
 	}
 
 	if err := s.elfRepo.DeactivateAll(); err != nil {
@@ -646,7 +659,7 @@ func (s *gleifReferenceService) SyncOrganizationalRoles() error {
 	}
 	records, dropped, dupCodes := dedupeOrganizationalRoles(records)
 	if dropped > 0 {
-		log.Warn().Int("dropped_duplicates", dropped).Strs("duplicate_codes", dupCodes).Msg("Dropped duplicate organizational role codes before upsert")
+		log.Info().Int("collapsed_rows", dropped).Int("affected_codes", len(dupCodes)).Strs("sample_codes", sampleKeys(dupCodes, 25)).Msg("Collapsed exact duplicate organizational role rows before upsert")
 	}
 
 	if err := s.roleRepo.DeactivateAll(); err != nil {
@@ -1055,13 +1068,20 @@ func dedupeEntityLegalForms(records []*domain.GLEIFEntityLegalForm) ([]*domain.G
 		if record == nil {
 			continue
 		}
-		key := strings.TrimSpace(record.ELFCode)
+		key := strings.Join([]string{
+			strings.TrimSpace(record.ELFCode),
+			strings.ToLower(strings.TrimSpace(record.LanguageCode)),
+			strings.ToUpper(strings.TrimSpace(record.CountryOfFormation)),
+			strings.ToUpper(strings.TrimSpace(record.CountrySubdivisionOfFormation)),
+			strings.TrimSpace(record.EntityLegalFormName),
+			strings.TrimSpace(record.Abbreviations),
+			strings.ToUpper(strings.TrimSpace(record.Status)),
+		}, "|")
 		if key == "" {
 			continue
 		}
-		if idx, ok := seen[key]; ok {
-			result[idx] = record
-			duplicateKeys[key] = struct{}{}
+		if _, ok := seen[key]; ok {
+			duplicateKeys[strings.TrimSpace(record.ELFCode)] = struct{}{}
 			dropped++
 			continue
 		}
@@ -1083,13 +1103,20 @@ func dedupeOrganizationalRoles(records []*domain.GLEIFOrganizationalRole) ([]*do
 		if record == nil {
 			continue
 		}
-		key := strings.TrimSpace(record.RoleCode)
+		key := strings.Join([]string{
+			strings.TrimSpace(record.RoleCode),
+			strings.ToLower(strings.TrimSpace(record.LanguageCode)),
+			strings.ToUpper(strings.TrimSpace(record.CountryCode)),
+			strings.ToUpper(strings.TrimSpace(record.CountrySubdivisionCode)),
+			strings.ToUpper(strings.TrimSpace(record.ELFCode)),
+			strings.TrimSpace(record.RoleName),
+			strings.TrimSpace(record.Description),
+		}, "|")
 		if key == "" {
 			continue
 		}
-		if idx, ok := seen[key]; ok {
-			result[idx] = record
-			duplicateKeys[key] = struct{}{}
+		if _, ok := seen[key]; ok {
+			duplicateKeys[strings.TrimSpace(record.RoleCode)] = struct{}{}
 			dropped++
 			continue
 		}
@@ -1135,6 +1162,13 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func sampleKeys(keys []string, max int) []string {
+	if max <= 0 || len(keys) <= max {
+		return keys
+	}
+	return keys[:max]
 }
 
 // sortedKeys returns a sorted slice of the keys from a string set.

--- a/backend/internal/service/gleif_reference_service.go
+++ b/backend/internal/service/gleif_reference_service.go
@@ -418,22 +418,29 @@ func parseOrganizationalRolesCSV(r io.ReadCloser) ([]*domain.GLEIFOrganizational
 			continue
 		}
 
-		languageCode := strings.ToLower(strings.TrimSpace(safeCol(row, 9)))
 		description := safeCol(row, 2)
+		languageCode := ""
+		elfCode := ""
+		countryOfFormation := ""
+		countrySubdivisionOfFormation := ""
 		if len(row) >= 19 {
+			languageCode = strings.ToLower(strings.TrimSpace(safeCol(row, 9)))
+			elfCode = strings.ToUpper(strings.TrimSpace(safeCol(row, 6)))
+			countryOfFormation = strings.ToUpper(strings.TrimSpace(safeCol(row, 2)))
+			countrySubdivisionOfFormation = strings.ToUpper(strings.TrimSpace(safeCol(row, 4)))
 			description = firstNonEmpty(safeCol(row, 18), safeCol(row, 17))
 		}
 
 		records = append(records, &domain.GLEIFOrganizationalRole{
-			RoleCode:               truncateString(strings.ToUpper(roleCode), 50),
-			RoleName:               truncateString(firstNonEmpty(safeCol(row, 10), safeCol(row, 7), safeCol(row, 1)), 500),
-			Description:            description,
-			LanguageCode:           truncateString(languageCode, 10),
-			ELFCode:                truncateString(strings.ToUpper(strings.TrimSpace(safeCol(row, 6))), 10),
-			CountryCode:            truncateString(strings.ToUpper(strings.TrimSpace(safeCol(row, 2))), 2),
-			CountrySubdivisionCode: truncateString(strings.ToUpper(strings.TrimSpace(safeCol(row, 4))), 10),
-			Active:                 true,
-			UpdatedBy:              "gleif_sync",
+			RoleCode:                      truncateString(strings.ToUpper(roleCode), 50),
+			RoleName:                      truncateString(firstNonEmpty(safeCol(row, 10), safeCol(row, 7), safeCol(row, 1)), 500),
+			Description:                   description,
+			LanguageCode:                  truncateString(languageCode, 10),
+			ELFCode:                       truncateString(elfCode, 10),
+			CountryOfFormation:            truncateString(countryOfFormation, 2),
+			CountrySubdivisionOfFormation: truncateString(countrySubdivisionOfFormation, 10),
+			Active:                        true,
+			UpdatedBy:                     "gleif_sync",
 		})
 	}
 	return records, nil
@@ -1106,8 +1113,8 @@ func dedupeOrganizationalRoles(records []*domain.GLEIFOrganizationalRole) ([]*do
 		key := strings.Join([]string{
 			strings.TrimSpace(record.RoleCode),
 			strings.ToLower(strings.TrimSpace(record.LanguageCode)),
-			strings.ToUpper(strings.TrimSpace(record.CountryCode)),
-			strings.ToUpper(strings.TrimSpace(record.CountrySubdivisionCode)),
+			strings.ToUpper(strings.TrimSpace(record.CountryOfFormation)),
+			strings.ToUpper(strings.TrimSpace(record.CountrySubdivisionOfFormation)),
 			strings.ToUpper(strings.TrimSpace(record.ELFCode)),
 			strings.TrimSpace(record.RoleName),
 			strings.TrimSpace(record.Description),

--- a/backend/internal/service/gleif_reference_service_test.go
+++ b/backend/internal/service/gleif_reference_service_test.go
@@ -267,6 +267,34 @@ func TestParseOrganizationalRolesCSV(t *testing.T) {
 	}
 }
 
+func TestParseOrganizationalRolesCSV_CommaFormatUsesTransliteratedNameAndLegislation(t *testing.T) {
+	csvData := "\"OOR Code\",\"Country of formation\",\"Country Code (ISO 3166-1)\",\"Jurisdiction of formation\",\"Country sub-division code (ISO 3166-2)\",\"Entity Legal Form name Local name (ELF)\",\"ELF Code\",\"Official Organizational Role (OOR)\",\"Language\",\"Language Code (ISO 639-1)\",\"OOR Transliterated name (per ISO 01-140-10)\",\"Abbreviations OOR Local language\",\"Abbreviations OOR transliterated\",\"Date created YYYY-MM-DD (ISO 8601)\",\"OOR Status ACTV/INAC\",\"Modification\",\"Modification date YYYY-MM-DD (ISO 8601)\",\"Reason\",\"Applicable legislation / regulation\"\n" +
+		"\"03EE4V\",\"France\",\"FR\",\"\",\"\",\"\",\"\",\"séquestre-gérant\",\"French\",\"fr\",\"receiver-manager\",\"\",\"\",\"2024-01-01\",\"ACTV\",\"\",\"\",\"\",\"Commercial Code\"\n"
+
+	records, err := parseOrganizationalRolesCSV(io.NopCloser(strings.NewReader(csvData)))
+	if err != nil {
+		t.Fatalf("parseOrganizationalRolesCSV: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if records[0].RoleCode != "03EE4V" {
+		t.Fatalf("expected role code 03EE4V, got %s", records[0].RoleCode)
+	}
+	if records[0].RoleName != "receiver-manager" {
+		t.Fatalf("expected transliterated role name, got %s", records[0].RoleName)
+	}
+	if records[0].Description != "Commercial Code" {
+		t.Fatalf("expected legislation as description, got %s", records[0].Description)
+	}
+	if records[0].LanguageCode != "fr" {
+		t.Fatalf("expected language code fr, got %s", records[0].LanguageCode)
+	}
+	if records[0].CountryCode != "FR" {
+		t.Fatalf("expected country code FR, got %s", records[0].CountryCode)
+	}
+}
+
 func TestParseLegalJurisdictionsCSV(t *testing.T) {
 	// Tab-separated: Code | Name | Country
 	csvData := "Code\tName\tCountry\n" +
@@ -332,8 +360,9 @@ func TestParseLegalJurisdictionsCSV_CommaFormat(t *testing.T) {
 
 func TestDedupeOrganizationalRoles(t *testing.T) {
 	roles := []*domain.GLEIFOrganizationalRole{
-		{RoleCode: "CEO", RoleName: "Chief Executive Officer"},
-		{RoleCode: "CEO", RoleName: "Chief Executive Officer Updated"},
+		{RoleCode: "CEO", RoleName: "Directeur general", LanguageCode: "fr", CountryCode: "FR"},
+		{RoleCode: "CEO", RoleName: "Chief Executive Officer", LanguageCode: "en", CountryCode: "FR"},
+		{RoleCode: "CEO", RoleName: "Chief Executive Officer", LanguageCode: "en", CountryCode: "FR"},
 		{RoleCode: "CFO", RoleName: "Chief Financial Officer"},
 	}
 
@@ -341,11 +370,14 @@ func TestDedupeOrganizationalRoles(t *testing.T) {
 	if dropped != 1 {
 		t.Fatalf("expected 1 dropped duplicate, got %d", dropped)
 	}
-	if len(deduped) != 2 {
-		t.Fatalf("expected 2 deduplicated roles, got %d", len(deduped))
+	if len(deduped) != 3 {
+		t.Fatalf("expected 3 deduplicated roles, got %d", len(deduped))
 	}
-	if deduped[0].RoleCode != "CEO" || deduped[0].RoleName != "Chief Executive Officer Updated" {
-		t.Fatalf("expected last duplicate to win for CEO, got %+v", deduped[0])
+	if deduped[0].RoleCode != "CEO" || deduped[0].LanguageCode != "fr" {
+		t.Fatalf("expected first multilingual CEO variant retained, got %+v", deduped[0])
+	}
+	if deduped[1].RoleCode != "CEO" || deduped[1].LanguageCode != "en" {
+		t.Fatalf("expected second multilingual CEO variant retained, got %+v", deduped[1])
 	}
 	if len(dupCodes) != 1 || dupCodes[0] != "CEO" {
 		t.Errorf("expected duplicate_codes=[CEO], got %v", dupCodes)

--- a/backend/internal/service/gleif_reference_service_test.go
+++ b/backend/internal/service/gleif_reference_service_test.go
@@ -246,6 +246,32 @@ func TestParseEntityLegalFormsCSV_TruncatesLongAbbreviations(t *testing.T) {
 	}
 }
 
+func TestDedupeEntityLegalForms_PreservesVariantsAndDropsExactDuplicates(t *testing.T) {
+	forms := []*domain.GLEIFEntityLegalForm{
+		{ELFCode: "106J", LanguageCode: "be", CountryOfFormation: "BY", EntityLegalFormName: "Belarusian Name", Status: "ACTIVE"},
+		{ELFCode: "106J", LanguageCode: "ru", CountryOfFormation: "BY", EntityLegalFormName: "Russian Name", Status: "ACTIVE"},
+		{ELFCode: "106J", LanguageCode: "ru", CountryOfFormation: "BY", EntityLegalFormName: "Russian Name", Status: "ACTIVE"},
+		{ELFCode: "ABCD", LanguageCode: "en", CountryOfFormation: "GB", EntityLegalFormName: "Limited", Status: "ACTIVE"},
+	}
+
+	deduped, dropped, dupCodes := dedupeEntityLegalForms(forms)
+	if dropped != 1 {
+		t.Fatalf("expected 1 dropped duplicate, got %d", dropped)
+	}
+	if len(deduped) != 3 {
+		t.Fatalf("expected 3 records after dedupe, got %d", len(deduped))
+	}
+	if deduped[0].ELFCode != "106J" || deduped[0].LanguageCode != "be" {
+		t.Fatalf("expected first variant preserved, got %+v", deduped[0])
+	}
+	if deduped[1].ELFCode != "106J" || deduped[1].LanguageCode != "ru" {
+		t.Fatalf("expected second variant preserved, got %+v", deduped[1])
+	}
+	if len(dupCodes) != 1 || dupCodes[0] != "106J" {
+		t.Fatalf("expected dupCodes=[106J], got %v", dupCodes)
+	}
+}
+
 func TestParseOrganizationalRolesCSV(t *testing.T) {
 	// Tab-separated: Role Code | Role Name | Description
 	csvData := "Role Code\tRole Name\tDescription\n" +
@@ -264,6 +290,9 @@ func TestParseOrganizationalRolesCSV(t *testing.T) {
 	}
 	if records[1].RoleName != "Chief Executive Officer" {
 		t.Errorf("unexpected role name: %s", records[1].RoleName)
+	}
+	if records[0].CountryOfFormation != "" || records[0].CountrySubdivisionOfFormation != "" || records[0].ELFCode != "" {
+		t.Fatalf("expected legacy TSV context fields to remain empty, got %+v", records[0])
 	}
 }
 
@@ -290,8 +319,8 @@ func TestParseOrganizationalRolesCSV_CommaFormatUsesTransliteratedNameAndLegisla
 	if records[0].LanguageCode != "fr" {
 		t.Fatalf("expected language code fr, got %s", records[0].LanguageCode)
 	}
-	if records[0].CountryCode != "FR" {
-		t.Fatalf("expected country code FR, got %s", records[0].CountryCode)
+	if records[0].CountryOfFormation != "FR" {
+		t.Fatalf("expected country code FR, got %s", records[0].CountryOfFormation)
 	}
 }
 
@@ -360,9 +389,9 @@ func TestParseLegalJurisdictionsCSV_CommaFormat(t *testing.T) {
 
 func TestDedupeOrganizationalRoles(t *testing.T) {
 	roles := []*domain.GLEIFOrganizationalRole{
-		{RoleCode: "CEO", RoleName: "Directeur general", LanguageCode: "fr", CountryCode: "FR"},
-		{RoleCode: "CEO", RoleName: "Chief Executive Officer", LanguageCode: "en", CountryCode: "FR"},
-		{RoleCode: "CEO", RoleName: "Chief Executive Officer", LanguageCode: "en", CountryCode: "FR"},
+		{RoleCode: "CEO", RoleName: "Directeur general", LanguageCode: "fr", CountryOfFormation: "FR"},
+		{RoleCode: "CEO", RoleName: "Chief Executive Officer", LanguageCode: "en", CountryOfFormation: "FR"},
+		{RoleCode: "CEO", RoleName: "Chief Executive Officer", LanguageCode: "en", CountryOfFormation: "FR"},
 		{RoleCode: "CFO", RoleName: "Chief Financial Officer"},
 	}
 

--- a/backend/migrations/000059_store_gleif_reference_multilingual_variants.down.sql
+++ b/backend/migrations/000059_store_gleif_reference_multilingual_variants.down.sql
@@ -25,6 +25,9 @@ WHERE t.elf_code IS NOT NULL
 DROP TRIGGER IF EXISTS trg_sync_gleif_elf_code_lookup
 ON lei_raw.gleif_entity_legal_forms;
 
+ALTER TABLE lei_raw.gleif_entity_legal_forms
+    DROP CONSTRAINT IF EXISTS fk_gleif_elf_variants_parent_code;
+
 DROP FUNCTION IF EXISTS lei_raw.sync_gleif_elf_code_lookup();
 
 DROP TRIGGER IF EXISTS update_gleif_elf_codes_updated_at

--- a/backend/migrations/000059_store_gleif_reference_multilingual_variants.down.sql
+++ b/backend/migrations/000059_store_gleif_reference_multilingual_variants.down.sql
@@ -3,11 +3,49 @@
 DROP INDEX IF EXISTS lei_raw.ux_gleif_elf_variant;
 DROP INDEX IF EXISTS lei_raw.ux_gleif_role_variant;
 
+ALTER TABLE lei_raw.lei_records
+        DROP CONSTRAINT IF EXISTS fk_lei_records_entity_legal_form;
+
+-- Down migration must collapse multilingual variants back to one row per code
+-- before restoring UNIQUE (elf_code).
+WITH keep AS (
+        SELECT DISTINCT ON (elf_code) id
+        FROM lei_raw.gleif_entity_legal_forms
+        WHERE elf_code IS NOT NULL AND BTRIM(elf_code) <> ''
+        ORDER BY elf_code,
+                         CASE WHEN COALESCE(language_code, '') = 'en' THEN 0 ELSE 1 END,
+                         updated_at DESC,
+                         created_at DESC
+)
+DELETE FROM lei_raw.gleif_entity_legal_forms t
+WHERE t.elf_code IS NOT NULL
+    AND BTRIM(t.elf_code) <> ''
+    AND NOT EXISTS (SELECT 1 FROM keep k WHERE k.id = t.id);
+
+DROP TRIGGER IF EXISTS trg_sync_gleif_elf_code_lookup
+ON lei_raw.gleif_entity_legal_forms;
+
+DROP FUNCTION IF EXISTS lei_raw.sync_gleif_elf_code_lookup();
+
+DROP TRIGGER IF EXISTS update_gleif_elf_codes_updated_at
+ON lei_raw.gleif_entity_legal_form_codes;
+
+DROP TABLE IF EXISTS lei_raw.gleif_entity_legal_form_codes;
+
 ALTER TABLE lei_raw.gleif_entity_legal_forms
     DROP CONSTRAINT IF EXISTS gleif_entity_legal_forms_elf_code_key;
 
 ALTER TABLE lei_raw.gleif_entity_legal_forms
     ADD CONSTRAINT gleif_entity_legal_forms_elf_code_key UNIQUE (elf_code);
+
+ALTER TABLE lei_raw.lei_records
+    ADD CONSTRAINT fk_lei_records_entity_legal_form
+        FOREIGN KEY (entity_legal_form)
+        REFERENCES lei_raw.gleif_entity_legal_forms (elf_code)
+        NOT VALID;
+
+ALTER TABLE lei_raw.lei_records
+    VALIDATE CONSTRAINT fk_lei_records_entity_legal_form;
 
 ALTER TABLE lei_raw.gleif_organizational_roles
     DROP CONSTRAINT IF EXISTS gleif_organizational_roles_role_code_key;

--- a/backend/migrations/000059_store_gleif_reference_multilingual_variants.down.sql
+++ b/backend/migrations/000059_store_gleif_reference_multilingual_variants.down.sql
@@ -50,6 +50,22 @@ ALTER TABLE lei_raw.lei_records
 ALTER TABLE lei_raw.lei_records
     VALIDATE CONSTRAINT fk_lei_records_entity_legal_form;
 
+-- Collapse role variants back to one row per code before restoring
+-- UNIQUE (role_code).
+WITH keep_role AS (
+        SELECT DISTINCT ON (role_code) id
+        FROM lei_raw.gleif_organizational_roles
+        WHERE role_code IS NOT NULL AND BTRIM(role_code) <> ''
+        ORDER BY role_code,
+                         CASE WHEN COALESCE(language_code, '') = 'en' THEN 0 ELSE 1 END,
+                         updated_at DESC,
+                         created_at DESC
+)
+DELETE FROM lei_raw.gleif_organizational_roles t
+WHERE t.role_code IS NOT NULL
+    AND BTRIM(t.role_code) <> ''
+    AND NOT EXISTS (SELECT 1 FROM keep_role k WHERE k.id = t.id);
+
 ALTER TABLE lei_raw.gleif_organizational_roles
     DROP CONSTRAINT IF EXISTS gleif_organizational_roles_role_code_key;
 

--- a/backend/migrations/000059_store_gleif_reference_multilingual_variants.down.sql
+++ b/backend/migrations/000059_store_gleif_reference_multilingual_variants.down.sql
@@ -1,0 +1,31 @@
+-- Revert multilingual/context variant storage for GLEIF reference tables.
+
+DROP INDEX IF EXISTS lei_raw.ux_gleif_elf_variant;
+DROP INDEX IF EXISTS lei_raw.ux_gleif_role_variant;
+
+ALTER TABLE lei_raw.gleif_entity_legal_forms
+    DROP CONSTRAINT IF EXISTS gleif_entity_legal_forms_elf_code_key;
+
+ALTER TABLE lei_raw.gleif_entity_legal_forms
+    ADD CONSTRAINT gleif_entity_legal_forms_elf_code_key UNIQUE (elf_code);
+
+ALTER TABLE lei_raw.gleif_organizational_roles
+    DROP CONSTRAINT IF EXISTS gleif_organizational_roles_role_code_key;
+
+ALTER TABLE lei_raw.gleif_organizational_roles
+    ADD CONSTRAINT gleif_organizational_roles_role_code_key UNIQUE (role_code);
+
+ALTER TABLE lei_raw.gleif_entity_legal_forms
+    ALTER COLUMN country_of_formation DROP NOT NULL,
+    ALTER COLUMN country_of_formation DROP DEFAULT,
+    ALTER COLUMN country_subdivision_of_formation DROP NOT NULL,
+    ALTER COLUMN country_subdivision_of_formation DROP DEFAULT;
+
+ALTER TABLE lei_raw.gleif_entity_legal_forms
+    DROP COLUMN IF EXISTS language_code;
+
+ALTER TABLE lei_raw.gleif_organizational_roles
+    DROP COLUMN IF EXISTS language_code,
+    DROP COLUMN IF EXISTS elf_code,
+    DROP COLUMN IF EXISTS country_of_formation,
+    DROP COLUMN IF EXISTS country_subdivision_of_formation;

--- a/backend/migrations/000059_store_gleif_reference_multilingual_variants.up.sql
+++ b/backend/migrations/000059_store_gleif_reference_multilingual_variants.up.sql
@@ -1,0 +1,64 @@
+-- Persist all valid multilingual/context variants from GLEIF reference lists.
+-- Previous schema enforced one row per code and collapsed valid rows.
+
+-- Entity legal forms: add language and make context columns non-null for stable composite uniqueness.
+ALTER TABLE lei_raw.gleif_entity_legal_forms
+    ADD COLUMN IF NOT EXISTS language_code VARCHAR(10) NOT NULL DEFAULT '';
+
+UPDATE lei_raw.gleif_entity_legal_forms
+SET country_of_formation = COALESCE(country_of_formation, ''),
+    country_subdivision_of_formation = COALESCE(country_subdivision_of_formation, ''),
+    language_code = COALESCE(language_code, '');
+
+ALTER TABLE lei_raw.gleif_entity_legal_forms
+    ALTER COLUMN country_of_formation SET DEFAULT '',
+    ALTER COLUMN country_of_formation SET NOT NULL,
+    ALTER COLUMN country_subdivision_of_formation SET DEFAULT '',
+    ALTER COLUMN country_subdivision_of_formation SET NOT NULL,
+    ALTER COLUMN language_code SET DEFAULT '',
+    ALTER COLUMN language_code SET NOT NULL;
+
+ALTER TABLE lei_raw.gleif_entity_legal_forms
+    DROP CONSTRAINT IF EXISTS gleif_entity_legal_forms_elf_code_key;
+
+DROP INDEX IF EXISTS lei_raw.idx_gleif_elf_elf_code;
+
+CREATE INDEX IF NOT EXISTS idx_gleif_elf_elf_code ON lei_raw.gleif_entity_legal_forms (elf_code);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_gleif_elf_variant
+    ON lei_raw.gleif_entity_legal_forms
+    (elf_code, language_code, country_of_formation, country_subdivision_of_formation, entity_legal_form_name, status);
+
+-- Organizational roles: add context columns required to persist all variants.
+ALTER TABLE lei_raw.gleif_organizational_roles
+    ADD COLUMN IF NOT EXISTS language_code VARCHAR(10) NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS elf_code VARCHAR(10) NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS country_of_formation VARCHAR(2) NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS country_subdivision_of_formation VARCHAR(10) NOT NULL DEFAULT '';
+
+UPDATE lei_raw.gleif_organizational_roles
+SET language_code = COALESCE(language_code, ''),
+    elf_code = COALESCE(elf_code, ''),
+    country_of_formation = COALESCE(country_of_formation, ''),
+    country_subdivision_of_formation = COALESCE(country_subdivision_of_formation, '');
+
+ALTER TABLE lei_raw.gleif_organizational_roles
+    ALTER COLUMN language_code SET DEFAULT '',
+    ALTER COLUMN language_code SET NOT NULL,
+    ALTER COLUMN elf_code SET DEFAULT '',
+    ALTER COLUMN elf_code SET NOT NULL,
+    ALTER COLUMN country_of_formation SET DEFAULT '',
+    ALTER COLUMN country_of_formation SET NOT NULL,
+    ALTER COLUMN country_subdivision_of_formation SET DEFAULT '',
+    ALTER COLUMN country_subdivision_of_formation SET NOT NULL;
+
+ALTER TABLE lei_raw.gleif_organizational_roles
+    DROP CONSTRAINT IF EXISTS gleif_organizational_roles_role_code_key;
+
+DROP INDEX IF EXISTS lei_raw.idx_gleif_roles_role_code;
+
+CREATE INDEX IF NOT EXISTS idx_gleif_roles_role_code ON lei_raw.gleif_organizational_roles (role_code);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_gleif_role_variant
+    ON lei_raw.gleif_organizational_roles
+    (role_code, language_code, country_of_formation, country_subdivision_of_formation, elf_code, role_name);

--- a/backend/migrations/000059_store_gleif_reference_multilingual_variants.up.sql
+++ b/backend/migrations/000059_store_gleif_reference_multilingual_variants.up.sql
@@ -1,6 +1,94 @@
 -- Persist all valid multilingual/context variants from GLEIF reference lists.
 -- Previous schema enforced one row per code and collapsed valid rows.
 
+-- Keep referential integrity from lei_records.entity_legal_form while allowing
+-- multiple rows per elf_code in gleif_entity_legal_forms.
+CREATE TABLE IF NOT EXISTS lei_raw.gleif_entity_legal_form_codes (
+    elf_code VARCHAR(10) PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO lei_raw.gleif_entity_legal_form_codes (elf_code)
+SELECT DISTINCT elf_code
+FROM lei_raw.gleif_entity_legal_forms
+WHERE elf_code IS NOT NULL AND BTRIM(elf_code) <> ''
+ON CONFLICT (elf_code) DO NOTHING;
+
+CREATE TRIGGER update_gleif_elf_codes_updated_at
+    BEFORE UPDATE ON lei_raw.gleif_entity_legal_form_codes
+    FOR EACH ROW
+    EXECUTE FUNCTION UPDATE_UPDATED_AT_COLUMN();
+
+CREATE OR REPLACE FUNCTION lei_raw.sync_gleif_elf_code_lookup()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.elf_code IS NOT NULL AND BTRIM(NEW.elf_code) <> '' THEN
+            INSERT INTO lei_raw.gleif_entity_legal_form_codes (elf_code)
+            VALUES (NEW.elf_code)
+            ON CONFLICT (elf_code) DO NOTHING;
+        END IF;
+        RETURN NEW;
+    ELSIF TG_OP = 'UPDATE' THEN
+        IF NEW.elf_code IS NOT NULL AND BTRIM(NEW.elf_code) <> '' THEN
+            INSERT INTO lei_raw.gleif_entity_legal_form_codes (elf_code)
+            VALUES (NEW.elf_code)
+            ON CONFLICT (elf_code) DO NOTHING;
+        END IF;
+
+        IF OLD.elf_code IS DISTINCT FROM NEW.elf_code
+           AND OLD.elf_code IS NOT NULL
+           AND BTRIM(OLD.elf_code) <> ''
+           AND NOT EXISTS (
+               SELECT 1
+               FROM lei_raw.gleif_entity_legal_forms
+               WHERE elf_code = OLD.elf_code
+                 AND id <> OLD.id
+           ) THEN
+            DELETE FROM lei_raw.gleif_entity_legal_form_codes
+            WHERE elf_code = OLD.elf_code;
+        END IF;
+        RETURN NEW;
+    ELSIF TG_OP = 'DELETE' THEN
+        IF OLD.elf_code IS NOT NULL
+           AND BTRIM(OLD.elf_code) <> ''
+           AND NOT EXISTS (
+               SELECT 1
+               FROM lei_raw.gleif_entity_legal_forms
+               WHERE elf_code = OLD.elf_code
+                 AND id <> OLD.id
+           ) THEN
+            DELETE FROM lei_raw.gleif_entity_legal_form_codes
+            WHERE elf_code = OLD.elf_code;
+        END IF;
+        RETURN OLD;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_sync_gleif_elf_code_lookup
+ON lei_raw.gleif_entity_legal_forms;
+
+CREATE TRIGGER trg_sync_gleif_elf_code_lookup
+    AFTER INSERT OR UPDATE OR DELETE ON lei_raw.gleif_entity_legal_forms
+    FOR EACH ROW
+    EXECUTE FUNCTION lei_raw.sync_gleif_elf_code_lookup();
+
+ALTER TABLE lei_raw.lei_records
+    DROP CONSTRAINT IF EXISTS fk_lei_records_entity_legal_form;
+
+ALTER TABLE lei_raw.lei_records
+    ADD CONSTRAINT fk_lei_records_entity_legal_form
+        FOREIGN KEY (entity_legal_form)
+        REFERENCES lei_raw.gleif_entity_legal_form_codes (elf_code)
+        NOT VALID;
+
+ALTER TABLE lei_raw.lei_records
+    VALIDATE CONSTRAINT fk_lei_records_entity_legal_form;
+
 -- Entity legal forms: add language and make context columns non-null for stable composite uniqueness.
 ALTER TABLE lei_raw.gleif_entity_legal_forms
     ADD COLUMN IF NOT EXISTS language_code VARCHAR(10) NOT NULL DEFAULT '';

--- a/backend/migrations/000059_store_gleif_reference_multilingual_variants.up.sql
+++ b/backend/migrations/000059_store_gleif_reference_multilingual_variants.up.sql
@@ -1,13 +1,19 @@
 -- Persist all valid multilingual/context variants from GLEIF reference lists.
 -- Previous schema enforced one row per code and collapsed valid rows.
 
--- Keep referential integrity from lei_records.entity_legal_form while allowing
--- multiple rows per elf_code in gleif_entity_legal_forms.
+-- Parent table for ELF codes. Child variants remain in
+-- lei_raw.gleif_entity_legal_forms.
 CREATE TABLE IF NOT EXISTS lei_raw.gleif_entity_legal_form_codes (
     elf_code VARCHAR(10) PRIMARY KEY,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+COMMENT ON TABLE lei_raw.gleif_entity_legal_form_codes IS
+'Parent code table for ELF values. FK target for lei_records.entity_legal_form and parent for multilingual ELF variants.';
+
+COMMENT ON COLUMN lei_raw.gleif_entity_legal_form_codes.elf_code IS
+'Canonical ELF code (ISO 20275).';
 
 INSERT INTO lei_raw.gleif_entity_legal_form_codes (elf_code)
 SELECT DISTINCT elf_code
@@ -88,6 +94,18 @@ ALTER TABLE lei_raw.lei_records
 
 ALTER TABLE lei_raw.lei_records
     VALIDATE CONSTRAINT fk_lei_records_entity_legal_form;
+
+ALTER TABLE lei_raw.gleif_entity_legal_forms
+    DROP CONSTRAINT IF EXISTS fk_gleif_elf_variants_parent_code;
+
+ALTER TABLE lei_raw.gleif_entity_legal_forms
+    ADD CONSTRAINT fk_gleif_elf_variants_parent_code
+        FOREIGN KEY (elf_code)
+        REFERENCES lei_raw.gleif_entity_legal_form_codes (elf_code)
+        NOT VALID;
+
+ALTER TABLE lei_raw.gleif_entity_legal_forms
+    VALIDATE CONSTRAINT fk_gleif_elf_variants_parent_code;
 
 -- Entity legal forms: add language and make context columns non-null for stable composite uniqueness.
 ALTER TABLE lei_raw.gleif_entity_legal_forms


### PR DESCRIPTION
## Summary
- persist all official GLEIF multilingual/context variants for Entity Legal Forms and Organizational Roles instead of collapsing by code
- add migration `000059_store_gleif_reference_multilingual_variants` to add variant columns and composite uniqueness constraints
- update GLEIF parsing/upsert logic so dedupe only removes exact duplicate variant rows
- keep LEI API display deterministic by selecting preferred ELF label per code in lookup queries

## Validation
- `go test ./internal/service -run GLEIF -count=1`
- `go test ./internal/repository -run ELF -count=1`