### PR TITLE
fix(ci): stabilize Security Scan in main

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -33,13 +33,13 @@ jobs:
           work-dir: backend
           repo-checkout: false
           output-format: sarif
-          output-file: govulncheck-results.sarif
+          output-file: backend/govulncheck-results.sarif
 
       - name: Upload govulncheck results to GitHub Security tab
-        if: always() && hashFiles('govulncheck-results.sarif') != ''
+        if: always() && hashFiles('backend/govulncheck-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: govulncheck-results.sarif
+          sarif_file: backend/govulncheck-results.sarif
           category: govulncheck
 
   security-scan:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -31,11 +31,12 @@ jobs:
         with:
           go-version-file: backend/go.mod
           work-dir: backend
+          repo-checkout: false
           output-format: sarif
           output-file: govulncheck-results.sarif
 
       - name: Upload govulncheck results to GitHub Security tab
-        if: always()
+        if: always() && hashFiles('govulncheck-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: govulncheck-results.sarif

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -5,10 +5,9 @@
 ARG DOCKER_LIBRARY=public.ecr.aws/docker/library
 FROM ${DOCKER_LIBRARY}/golang:1.25.1-alpine3.21 AS builder
 
-# Security: Upgrade libssl3 to address CVE vulnerabilities (Alert #117)
-# Version 3.3.6-r0 addresses critical SSL/TLS vulnerabilities
+# Security: keep OpenSSL patched using latest package available in Alpine repo.
 # security-scan-managed
-RUN apk add --no-cache --upgrade libssl3=3.3.6-r0
+RUN apk add --no-cache --upgrade libssl3
 
 WORKDIR /app
 
@@ -38,10 +37,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main cmd/api/main
 # Runtime stage
 FROM ${DOCKER_LIBRARY}/alpine:3.21
 
-# Security: Upgrade libssl3 to address CVE vulnerabilities (Alert #117)
-# Version 3.3.6-r0 addresses critical SSL/TLS vulnerabilities
+# Security: keep OpenSSL patched using latest package available in Alpine repo.
 # security-scan-managed
-RUN apk add --no-cache --upgrade libssl3=3.3.6-r0 ca-certificates=20250911-r0
+RUN apk add --no-cache --upgrade libssl3 ca-certificates=20250911-r0
 
 # Copy migrate from builder (compiled with current Go toolchain, no pre-built binary CVEs)
 COPY --from=builder /go/bin/migrate /usr/local/bin/migrate

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -7,6 +7,7 @@ FROM ${DOCKER_LIBRARY}/golang:1.25.1-alpine3.21 AS builder
 
 # Security: keep OpenSSL patched using latest package available in Alpine repo.
 # security-scan-managed
+# hadolint ignore=DL3018
 RUN apk add --no-cache --upgrade libssl3
 
 WORKDIR /app
@@ -39,7 +40,8 @@ FROM ${DOCKER_LIBRARY}/alpine:3.21
 
 # Security: keep OpenSSL patched using latest package available in Alpine repo.
 # security-scan-managed
-RUN apk add --no-cache --upgrade libssl3 ca-certificates=20250911-r0
+# hadolint ignore=DL3018
+RUN apk add --no-cache --upgrade libssl3 ca-certificates
 
 # Copy migrate from builder (compiled with current Go toolchain, no pre-built binary CVEs)
 COPY --from=builder /go/bin/migrate /usr/local/bin/migrate


### PR DESCRIPTION
## Why
Security Scan was failing repeatedly due to two infrastructure-level issues:
1. Backend Docker build used a brittle package strategy that caused lint/build instability.
2. govulncheck output/upload paths were inconsistent with work-dir handling.

## What changed
- Updated `.github/workflows/security-scan.yml`:
  - keep `repo-checkout: false` for `golang/govulncheck-action@v1`
  - write SARIF to `backend/govulncheck-results.sarif`
  - upload using the same `backend/...` path and matching `hashFiles()` guard
- Updated `docker/Dockerfile.backend`:
  - keep OpenSSL updated via `apk add --upgrade libssl3`
  - remove brittle runtime pin for `ca-certificates`
  - add explicit `hadolint` ignores for intentional unpinned security-upgrade lines (DL3018)

## Expected outcome
- Security Scan no longer fails from govulncheck SARIF path mismatch.
- Dockerfile lint no longer fails on intentional security upgrade lines.
- CI summary should pass once checks complete.
