### PR TITLE
fix: resolve reopened issues #292 #293 #294 #295 #299

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -25,7 +25,7 @@ blocked.
 
 #### 2. Markdown linting
 
-Runs `npx --yes markdownlint-cli2` against every staged `.md` file using the project rules in
+Runs `npx --no-install markdownlint-cli2` against every staged `.md` file using the project rules in
 `.markdownlint.yaml`.
 
 **Rules enforced:**
@@ -155,5 +155,5 @@ git config --unset core.hooksPath
 
 | Tool | Purpose | Install |
 | ---- | ------- | ------- |
-| `npx` with `markdownlint-cli2` | Markdown linting (pre-commit) | Install Node.js/npm, then run `npx --yes markdownlint-cli2 --version` |
+| `npx` with `markdownlint-cli2` | Markdown linting (pre-commit) | Install Node.js/npm and project tools, then run `npx --no-install markdownlint-cli2 --version` |
 | `pwsh` (PowerShell 7+) | VS Code settings + RA URL sorting (pre-commit, pre-push) | [Install PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) |

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -59,7 +59,7 @@ echo "Linting markdown files:"
 echo "$STAGED_MD_FILES"
 
 # Run markdownlint-cli2 on staged files using local dependencies only (no network installs in hooks)
-if echo "$STAGED_MD_FILES" | xargs npx --no-install markdownlint-cli2 --config .markdownlint.yaml; then
+if git diff --cached --name-only --diff-filter=ACM -z | tr '\0' '\n' | grep '\.md$' | tr '\n' '\0' | xargs -0 npx --no-install markdownlint-cli2 --config .markdownlint.yaml; then
     echo "✅ Markdown linting passed"
     exit 0
 else

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -58,8 +58,8 @@ fi
 echo "Linting markdown files:"
 echo "$STAGED_MD_FILES"
 
-# Run markdownlint-cli2 on staged files
-if echo "$STAGED_MD_FILES" | xargs npx --yes markdownlint-cli2 --config .markdownlint.yaml; then
+# Run markdownlint-cli2 on staged files using local dependencies only (no network installs in hooks)
+if echo "$STAGED_MD_FILES" | xargs npx --no-install markdownlint-cli2 --config .markdownlint.yaml; then
     echo "✅ Markdown linting passed"
     exit 0
 else
@@ -73,7 +73,10 @@ else
     echo ""
     echo "To fix automatically (where possible):"
     echo "  make lint-docs-fix"
-    echo "  or: npx --yes markdownlint-cli2 --config .markdownlint.yaml --fix <file>.md"
+    echo "  or: npx --no-install markdownlint-cli2 --config .markdownlint.yaml --fix <file>.md"
+    echo ""
+    echo "If markdownlint-cli2 is missing, install project tools first:"
+    echo "  make install-tools"
     echo ""
     echo "To skip this check (not recommended):"
     echo "  git commit --no-verify"

--- a/.github/workflows/aasc-weekly-rolling-checkin.yml
+++ b/.github/workflows/aasc-weekly-rolling-checkin.yml
@@ -12,9 +12,6 @@ concurrency:
   group: aasc-weekly-rolling-checkin
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   upsert-checkin:
     name: Upsert Issue 207 Rolling Comment

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -7,9 +7,6 @@ on:
 permissions:
   issues: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   auto-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -15,9 +15,6 @@ permissions:
   issues: write
   pull-requests: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   auto-label-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-line-endings.yml
+++ b/.github/workflows/check-line-endings.yml
@@ -9,9 +9,6 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   check-line-endings:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pr-issue-link.yml
+++ b/.github/workflows/check-pr-issue-link.yml
@@ -13,9 +13,6 @@ permissions:
   contents: read
   pull-requests: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   check-issue-link:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-user-pages.yml
+++ b/.github/workflows/docs-user-pages.yml
@@ -18,9 +18,6 @@ concurrency:
   group: pages-docs-user
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   build:
     name: Build docs-user site

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -11,9 +11,6 @@ on:
       - '**/*.md'
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   lint-markdown:
     runs-on: ubuntu-latest

--- a/.github/workflows/promote-dev-to-uat.yml
+++ b/.github/workflows/promote-dev-to-uat.yml
@@ -15,9 +15,6 @@ permissions:
   contents: read
   pull-requests: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   promote:
     name: Create promotion PR (dev → uat)

--- a/.github/workflows/promote-main-to-dev.yml
+++ b/.github/workflows/promote-main-to-dev.yml
@@ -17,9 +17,6 @@ permissions:
   contents: read
   pull-requests: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   promote:
     name: Create promotion PR (main → dev)

--- a/.github/workflows/promote-uat-to-prod.yml
+++ b/.github/workflows/promote-uat-to-prod.yml
@@ -15,9 +15,6 @@ permissions:
   contents: read
   pull-requests: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   promote:
     name: Create promotion PR (uat → prod)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,6 @@ permissions:
   contents: write  # Required for creating releases and uploading assets
   packages: write  # Required for pushing Docker images to GHCR
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   create-release:
     name: Create GitHub Release

--- a/.github/workflows/security-report.yml
+++ b/.github/workflows/security-report.yml
@@ -24,9 +24,6 @@ permissions:
   # the repository's Dependabot alerts to be enabled. If the step below errors,
   # check Settings → Code security → Dependabot alerts.
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   generate-report:
     name: Generate Security Report

--- a/.github/workflows/security-scan-enhanced.yml
+++ b/.github/workflows/security-scan-enhanced.yml
@@ -24,9 +24,6 @@ permissions:
   pull-requests: write
   security-events: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   security-scan-and-update:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -12,9 +12,6 @@ on:
       - 'backend/go.sum'
       - '.github/workflows/security-scan.yml'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   govulncheck:
     name: Go Vulnerability Check (govulncheck)

--- a/.github/workflows/sync-issue-status-from-pr.yml
+++ b/.github/workflows/sync-issue-status-from-pr.yml
@@ -14,9 +14,6 @@ permissions:
   issues: write
   pull-requests: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   sync-issue-status:
     runs-on: ubuntu-latest

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -111,9 +111,15 @@ func Load() (*Config, error) {
 
 	// Bind user-friendly env var names for Playwright testing configuration.
 	// These override the default TESTING_* prefix that AutomaticEnv would produce.
-	_ = viper.BindEnv("testing.playwrightseeduser", "PLAYWRIGHT_SEED_USER")
-	_ = viper.BindEnv("testing.playwrightuseremail", "PLAYWRIGHT_USER_EMAIL")
-	_ = viper.BindEnv("testing.playwrightuserpassword", "PLAYWRIGHT_USER_PASSWORD")
+	if err := viper.BindEnv("testing.playwrightseeduser", "PLAYWRIGHT_SEED_USER"); err != nil {
+		return nil, err
+	}
+	if err := viper.BindEnv("testing.playwrightuseremail", "PLAYWRIGHT_USER_EMAIL"); err != nil {
+		return nil, err
+	}
+	if err := viper.BindEnv("testing.playwrightuserpassword", "PLAYWRIGHT_USER_PASSWORD"); err != nil {
+		return nil, err
+	}
 
 	var config Config
 	if err := viper.Unmarshal(&config); err != nil {

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -287,6 +287,63 @@ func (s *authService) IsBootstrapAccount(userID string) bool {
 // startup. This ID must never be used in UAT or production deployments.
 const playwrightTestUserID = "00000000-0000-0000-0000-000000000002"
 
+func validatePlaywrightSeedCredentials(email, password string) error {
+	normalizedEmail := strings.TrimSpace(strings.ToLower(email))
+	normalizedPassword := strings.TrimSpace(password)
+	if normalizedEmail == "" {
+		return errors.New("playwright test user email is required")
+	}
+	if normalizedPassword == "" {
+		return errors.New("playwright test user password is required")
+	}
+
+	atIdx := strings.LastIndex(normalizedEmail, "@")
+	if atIdx <= 0 || atIdx == len(normalizedEmail)-1 {
+		return fmt.Errorf("playwright test user email must be a valid dev/test address: %q", email)
+	}
+
+	username := normalizedEmail[:atIdx]
+	domainPart := normalizedEmail[atIdx+1:]
+	allowedDomains := []string{"localhost", "example.com"}
+	allowedDomainSuffixes := []string{".local", ".test"}
+
+	isAllowedDomain := false
+	for _, allowedDomain := range allowedDomains {
+		if domainPart == allowedDomain {
+			isAllowedDomain = true
+			break
+		}
+	}
+	if !isAllowedDomain {
+		for _, suffix := range allowedDomainSuffixes {
+			if strings.HasSuffix(domainPart, suffix) {
+				isAllowedDomain = true
+				break
+			}
+		}
+	}
+	if !isAllowedDomain {
+		return fmt.Errorf("refusing to seed playwright test user for non-dev/test email domain: %q", email)
+	}
+
+	normalizedPasswordLower := strings.ToLower(normalizedPassword)
+	disallowedPasswords := map[string]struct{}{
+		"password":    {},
+		"password123": {},
+		"changeme":    {},
+		"admin":       {},
+		"playwright":  {},
+	}
+	if _, found := disallowedPasswords[normalizedPasswordLower]; found {
+		return errors.New("refusing to seed playwright test user with a default or weak password")
+	}
+	if normalizedPasswordLower == normalizedEmail || normalizedPasswordLower == username {
+		return errors.New("refusing to seed playwright test user with a predictable password")
+	}
+
+	return nil
+}
+
 // EnsurePlaywrightTestUser creates or reactivates a dedicated Playwright test
 // user so that end-to-end tests can authenticate without manual setup.
 // The user is always given role=admin so that tests can exercise every
@@ -297,6 +354,10 @@ const playwrightTestUserID = "00000000-0000-0000-0000-000000000002"
 // The caller (main.go) is responsible for gate-checking the config flag before
 // invoking this method.
 func (s *authService) EnsurePlaywrightTestUser(email, password string) error {
+	if err := validatePlaywrightSeedCredentials(email, password); err != nil {
+		return fmt.Errorf("playwright test user seeding blocked: %w", err)
+	}
+
 	// Derive a username from the local part of the email address (e.g.
 	// "playwright" from "playwright@axiom.local") so the username stays
 	// consistent with whatever email is configured.

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -296,6 +296,9 @@ func validatePlaywrightSeedCredentials(email, password string) error {
 	if normalizedPassword == "" {
 		return errors.New("playwright test user password is required")
 	}
+	if strings.Count(normalizedEmail, "@") != 1 {
+		return fmt.Errorf("playwright test user email must contain exactly one '@': %q", email)
+	}
 
 	atIdx := strings.LastIndex(normalizedEmail, "@")
 	if atIdx <= 0 || atIdx == len(normalizedEmail)-1 {
@@ -304,6 +307,9 @@ func validatePlaywrightSeedCredentials(email, password string) error {
 
 	username := normalizedEmail[:atIdx]
 	domainPart := normalizedEmail[atIdx+1:]
+	if strings.Contains(domainPart, "@") {
+		return fmt.Errorf("playwright test user email must be a valid dev/test address: %q", email)
+	}
 	allowedDomains := []string{"localhost", "example.com"}
 	allowedDomainSuffixes := []string{".local", ".test"}
 

--- a/backend/internal/service/auth_service_test.go
+++ b/backend/internal/service/auth_service_test.go
@@ -881,3 +881,36 @@ func TestEnsurePlaywrightTestUser_EmailConflict_GracefulSkip(t *testing.T) {
 		t.Errorf("expected graceful skip on email conflict, got error: %v", err)
 	}
 }
+
+func TestEnsurePlaywrightTestUser_RejectsNonDevEmailDomain(t *testing.T) {
+	repo := newAuthRepoStub()
+	svc := newSvc(repo)
+
+	err := svc.EnsurePlaywrightTestUser("playwright@company.com", pwPassword)
+	if err == nil || !strings.Contains(err.Error(), "seeding blocked") {
+		t.Fatalf("expected blocked seed error, got: %v", err)
+	}
+}
+
+func TestEnsurePlaywrightTestUser_RejectsWeakOrPredictablePassword(t *testing.T) {
+	tests := []struct {
+		name     string
+		email    string
+		password string
+	}{
+		{name: "weak default password", email: pwEmail, password: "password123"},
+		{name: "password equals email", email: pwEmail, password: pwEmail},
+		{name: "password equals username", email: pwEmail, password: "playwright"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newAuthRepoStub()
+			svc := newSvc(repo)
+			err := svc.EnsurePlaywrightTestUser(tc.email, tc.password)
+			if err == nil || !strings.Contains(err.Error(), "seeding blocked") {
+				t.Fatalf("expected blocked seed error, got: %v", err)
+			}
+		})
+	}
+}

--- a/backend/internal/service/auth_service_test.go
+++ b/backend/internal/service/auth_service_test.go
@@ -892,6 +892,16 @@ func TestEnsurePlaywrightTestUser_RejectsNonDevEmailDomain(t *testing.T) {
 	}
 }
 
+func TestEnsurePlaywrightTestUser_RejectsEmailWithMultipleAtSigns(t *testing.T) {
+	repo := newAuthRepoStub()
+	svc := newSvc(repo)
+
+	err := svc.EnsurePlaywrightTestUser("admin@company.com@localhost", pwPassword)
+	if err == nil || !strings.Contains(err.Error(), "seeding blocked") {
+		t.Fatalf("expected blocked seed error, got: %v", err)
+	}
+}
+
 func TestEnsurePlaywrightTestUser_RejectsWeakOrPredictablePassword(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/backend/migrations/000055_add_repex_exception_reasons_jsonb.up.sql
+++ b/backend/migrations/000055_add_repex_exception_reasons_jsonb.up.sql
@@ -4,10 +4,12 @@ ALTER TABLE lei_raw.lei_reporting_exceptions
 UPDATE lei_raw.lei_reporting_exceptions
 SET exception_reasons = COALESCE(
     (
-        SELECT jsonb_agg(trimmed_reason)
+        SELECT jsonb_agg(trimmed_reason ORDER BY ordinality)
         FROM (
-            SELECT NULLIF(BTRIM(reason_part), '') AS trimmed_reason
-            FROM unnest(string_to_array(COALESCE(exception_reason, ''), ',')) AS reason_part
+            SELECT
+                NULLIF(BTRIM(reason_part), '') AS trimmed_reason,
+                ordinality
+            FROM unnest(string_to_array(COALESCE(exception_reason, ''), ',')) WITH ORDINALITY AS parsed_parts(reason_part, ordinality)
         ) parsed
         WHERE trimmed_reason IS NOT NULL
     ),


### PR DESCRIPTION
## Summary
This PR addresses the reopened issues that were still present in current HEAD.

### Fixes included
- #292: made REPEX JSON aggregation deterministic with `WITH ORDINALITY` and `ORDER BY ordinality`.
- #293: removed network-capable `npx --yes` usage in pre-commit hook and switched to local-only `npx --no-install`.
- #294: added defense-in-depth validation for Playwright seed credentials (dev/test domain gating + weak/predictable password rejection) and tests.
- #295: removed unsupported `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env usage from workflow files.
- #299: stopped ignoring `viper.BindEnv` errors; `Load()` now returns binding errors.

## Validation
- `go test ./internal/service -run EnsurePlaywrightTestUser -count=1`
- `go test ./internal/config -count=1`
- `make docs-check`

Closes #292
Closes #293
Closes #294
Closes #295
Closes #299