### PR TITLE
docs(process): mirror PR progress updates to linked issues

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -629,7 +629,9 @@ When an AI agent creates a pull request, it should complete standard PR hygiene 
    - what validation/tests were run,
    - any follow-up actions or known limitations.
 5. For each linked underlying issue (for example `Fixes #123`, `Closes #123`, or issue references in PR description),
-   post a concise issue update comment after each PR push that includes:
+   post a concise issue update comment after each PR push (same per-push trigger as
+   [`instructions/copilot-pr-feedback-resolution.instructions.md`](instructions/copilot-pr-feedback-resolution.instructions.md))
+   that includes:
    - implementation status,
    - validation status,
    - testing guidance for user/UAT verification,

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -628,7 +628,13 @@ When an AI agent creates a pull request, it should complete standard PR hygiene 
    - what changed,
    - what validation/tests were run,
    - any follow-up actions or known limitations.
-5. Do not ask whether to post the summary/checklist comments; post them by default.
+5. For each linked underlying issue (for example `Fixes #123`, `Closes #123`, or issue references in PR description),
+   post a concise issue update comment after each PR push that includes:
+   - implementation status,
+   - validation status,
+   - testing guidance for user/UAT verification,
+   - PR link.
+6. Do not ask whether to post the summary/checklist/issue-update comments; post them by default.
 
 Only ask follow-up questions if required metadata cannot be applied (for example, reviewer handle is unavailable).
 

--- a/.github/instructions/copilot-pr-feedback-resolution.instructions.md
+++ b/.github/instructions/copilot-pr-feedback-resolution.instructions.md
@@ -135,6 +135,24 @@ After pushing all fixes and individual resolution comments, **automatically post
 gh pr comment {pr_number} --body "[Generated summary from Step 5 below]"
 ```
 
+## Step 4.5: Mirror Updates To Linked Issues
+
+After posting PR updates, automatically post concise status updates on each linked underlying issue (for example
+`Fixes #123`, `Closes #123`, or issues referenced in the PR body).
+
+**Post on each linked issue:**
+
+```bash
+gh issue comment {issue_number} --repo {owner}/{repo} --body "[Status update with testing guidance]"
+```
+
+Include:
+
+- implementation status,
+- validation/test results,
+- user/UAT testing guidance,
+- direct PR link.
+
 ## Step 5: Generate Comprehensive Summary
 
 **Structure:**
@@ -205,6 +223,7 @@ If any comments are deferred for later:
 
 - **Individual resolutions**: Reply directly to the Copilot comment thread using `--reply-to {comment_id}`
 - **Summary comment**: Post as standalone comment on the PR using `gh pr comment`
+- **Issue updates**: Post concise mirrored updates on linked underlying issues using `gh issue comment`
 - **Never duplicate**: Don't post the same resolution in multiple places
 
 ## Error Handling

--- a/.github/instructions/copilot-pr-feedback-resolution.instructions.md
+++ b/.github/instructions/copilot-pr-feedback-resolution.instructions.md
@@ -135,12 +135,13 @@ After pushing all fixes and individual resolution comments, **automatically post
 gh pr comment {pr_number} --body "[Generated summary from Step 5 below]"
 ```
 
-## Step 4.5: Mirror Updates To Linked Issues
+## Step 4.5: Mirror Updates To Linked Issues After Each Push
 
-After posting PR updates, automatically post concise status updates on each linked underlying issue (for example
-`Fixes #123`, `Closes #123`, or issues referenced in the PR body).
+After each push where you post PR status or resolution comments, automatically post concise status updates on each
+linked underlying issue (for example `Fixes #123`, `Closes #123`, or issues referenced in the PR body). Do not wait
+until the final PR summary comment.
 
-**Post on each linked issue:**
+**Post on each linked issue after each relevant push:**
 
 ```bash
 gh issue comment {issue_number} --repo {owner}/{repo} --body "[Status update with testing guidance]"


### PR DESCRIPTION
## Summary
- Update team-level Copilot policy so agents must mirror status updates on linked underlying issues, not only PR comments.
- Extend PR feedback-resolution workflow with an explicit step for posting linked-issue updates.
- Clarify comment scope expectations: thread replies + PR summary + issue updates.

## Validation
- `make docs-check-fix`
- `make docs-check`
- Result: markdown lint passed.

## Why
This improves user/UAT visibility by keeping issue threads current with implementation and testing status as PRs evolve.