### PR TITLE
fix: resolve GLEIF ELF duplicate-key sync failure (#349)

### DIFF
--- a/backend/internal/domain/lei_reference_models.go
+++ b/backend/internal/domain/lei_reference_models.go
@@ -53,6 +53,23 @@ func (GLEIFEntityLegalForm) TableName() string {
 	return "lei_raw.gleif_entity_legal_forms"
 }
 
+// GLEIFEntityLegalFormAudit records lifecycle changes for ELF variants.
+type GLEIFEntityLegalFormAudit struct {
+	ID             uuid.UUID   `gorm:"type:uuid;primary_key;default:gen_random_uuid()" json:"id"`
+	ELFVariantID   *uuid.UUID  `gorm:"type:uuid;index" json:"elf_variant_id"`
+	ELFCode        string      `gorm:"column:elf_code;size:10;not null;index" json:"elf_code"`
+	Action         string      `gorm:"size:20;not null" json:"action"`
+	RecordSnapshot JSONBString `gorm:"type:jsonb;not null" json:"record_snapshot"`
+	ChangedFields  JSONBString `gorm:"type:jsonb" json:"changed_fields"`
+	ChangedBy      string      `gorm:"size:100;not null;default:'system'" json:"changed_by"`
+	CreatedAt      time.Time   `json:"created_at"`
+}
+
+// TableName sets the GORM table name.
+func (GLEIFEntityLegalFormAudit) TableName() string {
+	return "lei_raw.gleif_entity_legal_forms_audit"
+}
+
 // GLEIFOrganizationalRole represents an ISO 5009 Official Organizational Role reference record.
 // Source: GLEIF organizational roles code list (CSV).
 // Resolves role codes in LEI Level 2 data to human-readable role names.

--- a/backend/internal/repository/gleif_reference_repository.go
+++ b/backend/internal/repository/gleif_reference_repository.go
@@ -71,6 +71,7 @@ type GLEIFEntityLegalFormRepository interface {
 	Upsert(records []*domain.GLEIFEntityLegalForm) error
 	Count() (int64, error)
 	FindAll(limit, offset int) ([]*domain.GLEIFEntityLegalForm, error)
+	FindAllForSync() ([]*domain.GLEIFEntityLegalForm, error)
 	FindByELFCode(elfCode string) (*domain.GLEIFEntityLegalForm, error)
 	DeactivateAll() error
 }
@@ -92,13 +93,10 @@ func (r *gleifEntityLegalFormRepository) Upsert(records []*domain.GLEIFEntityLeg
 		Columns: []clause.Column{
 			{Name: "elf_code"},
 			{Name: "language_code"},
-			{Name: "country_of_formation"},
 			{Name: "country_subdivision_of_formation"},
-			{Name: "entity_legal_form_name"},
-			{Name: "status"},
 		},
 		DoUpdates: clause.AssignmentColumns([]string{
-			"abbreviations", "updated_by", "updated_at",
+			"entity_legal_form_name", "abbreviations", "country_of_formation", "status", "updated_by", "updated_at",
 		}),
 	}).Create(records).Error
 }
@@ -117,6 +115,13 @@ func (r *gleifEntityLegalFormRepository) FindAll(limit, offset int) ([]*domain.G
 	return records, err
 }
 
+func (r *gleifEntityLegalFormRepository) FindAllForSync() ([]*domain.GLEIFEntityLegalForm, error) {
+	var records []*domain.GLEIFEntityLegalForm
+	err := r.db.Order("elf_code ASC, language_code ASC, country_of_formation ASC, country_subdivision_of_formation ASC, entity_legal_form_name ASC").
+		Find(&records).Error
+	return records, err
+}
+
 func (r *gleifEntityLegalFormRepository) FindByELFCode(elfCode string) (*domain.GLEIFEntityLegalForm, error) {
 	var record domain.GLEIFEntityLegalForm
 	err := r.db.Where("elf_code = ?", elfCode).First(&record).Error
@@ -130,6 +135,27 @@ func (r *gleifEntityLegalFormRepository) DeactivateAll() error {
 	return r.db.Model(&domain.GLEIFEntityLegalForm{}).
 		Where("status = ?", "ACTIVE").
 		Update("status", "DECOMMISSIONED").Error
+}
+
+// GLEIFEntityLegalFormAuditRepository stores lifecycle changes for ELF variants.
+type GLEIFEntityLegalFormAuditRepository interface {
+	UpsertAuditRecords(records []*domain.GLEIFEntityLegalFormAudit) error
+}
+
+type gleifEntityLegalFormAuditRepository struct {
+	db *gorm.DB
+}
+
+// NewGLEIFEntityLegalFormAuditRepository creates a new GLEIFEntityLegalFormAuditRepository.
+func NewGLEIFEntityLegalFormAuditRepository(db *gorm.DB) GLEIFEntityLegalFormAuditRepository {
+	return &gleifEntityLegalFormAuditRepository{db: db}
+}
+
+func (r *gleifEntityLegalFormAuditRepository) UpsertAuditRecords(records []*domain.GLEIFEntityLegalFormAudit) error {
+	if len(records) == 0 {
+		return nil
+	}
+	return r.db.Create(records).Error
 }
 
 // GLEIFOrganizationalRoleRepository defines data access for GLEIF organizational roles.

--- a/backend/internal/repository/gleif_reference_repository.go
+++ b/backend/internal/repository/gleif_reference_repository.go
@@ -155,7 +155,7 @@ func (r *gleifEntityLegalFormAuditRepository) UpsertAuditRecords(records []*doma
 	if len(records) == 0 {
 		return nil
 	}
-	return r.db.Create(records).Error
+	return r.db.CreateInBatches(records, 500).Error
 }
 
 // GLEIFOrganizationalRoleRepository defines data access for GLEIF organizational roles.

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -25,6 +25,7 @@ type Repositories struct {
 	UITranslation              UITranslationRepository
 	GLEIFRegistrationAuthority GLEIFRegistrationAuthorityRepository
 	GLEIFEntityLegalForm       GLEIFEntityLegalFormRepository
+	GLEIFEntityLegalFormAudit  GLEIFEntityLegalFormAuditRepository
 	GLEIFOrganizationalRole    GLEIFOrganizationalRoleRepository
 	GLEIFLegalJurisdiction     GLEIFLegalJurisdictionRepository
 }
@@ -48,6 +49,7 @@ func NewRepositories(db *gorm.DB) *Repositories {
 		UITranslation:              NewUITranslationRepository(db),
 		GLEIFRegistrationAuthority: NewGLEIFRegistrationAuthorityRepository(db),
 		GLEIFEntityLegalForm:       NewGLEIFEntityLegalFormRepository(db),
+		GLEIFEntityLegalFormAudit:  NewGLEIFEntityLegalFormAuditRepository(db),
 		GLEIFOrganizationalRole:    NewGLEIFOrganizationalRoleRepository(db),
 		GLEIFLegalJurisdiction:     NewGLEIFLegalJurisdictionRepository(db),
 	}

--- a/backend/internal/service/gleif_reference_service.go
+++ b/backend/internal/service/gleif_reference_service.go
@@ -103,15 +103,16 @@ func DefaultGLEIFReferenceURLs() GLEIFReferenceURLs {
 }
 
 type gleifReferenceService struct {
-	raRepo    repository.GLEIFRegistrationAuthorityRepository
-	elfRepo   repository.GLEIFEntityLegalFormRepository
-	roleRepo  repository.GLEIFOrganizationalRoleRepository
-	jurRepo   repository.GLEIFLegalJurisdictionRepository
-	client    *http.Client
-	urls      GLEIFReferenceURLs
-	dataDir   string
-	statsMu   sync.RWMutex
-	lastStats GLEIFSyncStats
+	raRepo       repository.GLEIFRegistrationAuthorityRepository
+	elfRepo      repository.GLEIFEntityLegalFormRepository
+	elfAuditRepo repository.GLEIFEntityLegalFormAuditRepository
+	roleRepo     repository.GLEIFOrganizationalRoleRepository
+	jurRepo      repository.GLEIFLegalJurisdictionRepository
+	client       *http.Client
+	urls         GLEIFReferenceURLs
+	dataDir      string
+	statsMu      sync.RWMutex
+	lastStats    GLEIFSyncStats
 }
 
 // NewGLEIFReferenceService creates a new GLEIFReferenceService using the production GLEIF URLs.
@@ -120,30 +121,33 @@ type gleifReferenceService struct {
 func NewGLEIFReferenceService(
 	raRepo repository.GLEIFRegistrationAuthorityRepository,
 	elfRepo repository.GLEIFEntityLegalFormRepository,
+	elfAuditRepo repository.GLEIFEntityLegalFormAuditRepository,
 	roleRepo repository.GLEIFOrganizationalRoleRepository,
 	jurRepo repository.GLEIFLegalJurisdictionRepository,
 	leiDataDir string,
 ) GLEIFReferenceService {
-	return NewGLEIFReferenceServiceWithURLs(raRepo, elfRepo, roleRepo, jurRepo, leiDataDir, DefaultGLEIFReferenceURLs())
+	return NewGLEIFReferenceServiceWithURLs(raRepo, elfRepo, elfAuditRepo, roleRepo, jurRepo, leiDataDir, DefaultGLEIFReferenceURLs())
 }
 
 // NewGLEIFReferenceServiceWithURLs creates a new GLEIFReferenceService with explicit CSV source URLs.
 func NewGLEIFReferenceServiceWithURLs(
 	raRepo repository.GLEIFRegistrationAuthorityRepository,
 	elfRepo repository.GLEIFEntityLegalFormRepository,
+	elfAuditRepo repository.GLEIFEntityLegalFormAuditRepository,
 	roleRepo repository.GLEIFOrganizationalRoleRepository,
 	jurRepo repository.GLEIFLegalJurisdictionRepository,
 	leiDataDir string,
 	urls GLEIFReferenceURLs,
 ) GLEIFReferenceService {
 	return &gleifReferenceService{
-		raRepo:   raRepo,
-		elfRepo:  elfRepo,
-		roleRepo: roleRepo,
-		jurRepo:  jurRepo,
-		client:   &http.Client{Timeout: gleifHTTPTimeout},
-		urls:     urls,
-		dataDir:  filepath.Join(leiDataDir, "gleif-reference"),
+		raRepo:       raRepo,
+		elfRepo:      elfRepo,
+		elfAuditRepo: elfAuditRepo,
+		roleRepo:     roleRepo,
+		jurRepo:      jurRepo,
+		client:       &http.Client{Timeout: gleifHTTPTimeout},
+		urls:         urls,
+		dataDir:      filepath.Join(leiDataDir, "gleif-reference"),
 	}
 }
 
@@ -619,6 +623,62 @@ func (s *gleifReferenceService) SyncEntityLegalForms() error {
 		log.Info().Int("collapsed_rows", dropped).Int("affected_codes", len(dupCodes)).Strs("sample_codes", sampleKeys(dupCodes, 25)).Msg("Collapsed exact duplicate entity legal form rows before upsert")
 	}
 
+	existingRecords, err := s.elfRepo.FindAllForSync()
+	if err != nil {
+		return fmt.Errorf("load existing entity legal forms: %w", err)
+	}
+	existingByKey := make(map[string]*domain.GLEIFEntityLegalForm, len(existingRecords))
+	for _, existing := range existingRecords {
+		if existing == nil {
+			continue
+		}
+		key := elfVariantKey(existing)
+		if key == "" {
+			continue
+		}
+		if current, found := existingByKey[key]; !found || shouldPreferELFRecord(existing, current) {
+			existingByKey[key] = existing
+		}
+	}
+
+	incomingByKey := make(map[string]*domain.GLEIFEntityLegalForm, len(records))
+	for _, rec := range records {
+		if rec == nil {
+			continue
+		}
+		key := elfVariantKey(rec)
+		if key == "" {
+			continue
+		}
+		if current, found := incomingByKey[key]; !found || shouldPreferELFRecord(rec, current) {
+			incomingByKey[key] = rec
+		}
+	}
+
+	auditRecords := make([]*domain.GLEIFEntityLegalFormAudit, 0, len(records))
+	for key, incoming := range incomingByKey {
+		existing, found := existingByKey[key]
+		if !found {
+			auditRecords = append(auditRecords, buildELFAuditRecord(nil, incoming, "CREATE"))
+			continue
+		}
+		if changedFields := buildELFChangedFields(existing, incoming); changedFields != "{}" {
+			auditRecords = append(auditRecords, buildELFAuditRecord(existing, incoming, "UPDATE"))
+		}
+	}
+
+	for key, existing := range existingByKey {
+		if _, found := incomingByKey[key]; found {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(existing.Status), "DECOMMISSIONED") {
+			continue
+		}
+		decommissioned := *existing
+		decommissioned.Status = "DECOMMISSIONED"
+		auditRecords = append(auditRecords, buildELFAuditRecord(existing, &decommissioned, "UPDATE"))
+	}
+
 	if err := s.elfRepo.DeactivateAll(); err != nil {
 		return fmt.Errorf("deactivate entity legal forms: %w", err)
 	}
@@ -630,6 +690,12 @@ func (s *gleifReferenceService) SyncEntityLegalForms() error {
 		}
 		if err := s.elfRepo.Upsert(records[i:end]); err != nil {
 			return fmt.Errorf("upsert entity legal forms batch: %w", err)
+		}
+	}
+
+	if s.elfAuditRepo != nil {
+		if err := s.elfAuditRepo.UpsertAuditRecords(auditRecords); err != nil {
+			return fmt.Errorf("write entity legal form audit records: %w", err)
 		}
 	}
 
@@ -1159,6 +1225,95 @@ func dedupeLegalJurisdictions(records []*domain.GLEIFLegalJurisdiction) ([]*doma
 		result = append(result, record)
 	}
 	return result, dropped, sortedKeys(duplicateKeys)
+}
+
+func elfVariantKey(record *domain.GLEIFEntityLegalForm) string {
+	if record == nil {
+		return ""
+	}
+	return strings.Join([]string{
+		strings.TrimSpace(record.ELFCode),
+		strings.ToLower(strings.TrimSpace(record.LanguageCode)),
+		strings.ToUpper(strings.TrimSpace(record.CountrySubdivisionOfFormation)),
+	}, "|")
+}
+
+func shouldPreferELFRecord(candidate, current *domain.GLEIFEntityLegalForm) bool {
+	if current == nil {
+		return true
+	}
+	candidateActive := strings.EqualFold(strings.TrimSpace(candidate.Status), "ACTIVE")
+	currentActive := strings.EqualFold(strings.TrimSpace(current.Status), "ACTIVE")
+	if candidateActive != currentActive {
+		return candidateActive
+	}
+	if !candidate.UpdatedAt.Equal(current.UpdatedAt) {
+		return candidate.UpdatedAt.After(current.UpdatedAt)
+	}
+	return candidate.CreatedAt.After(current.CreatedAt)
+}
+
+func buildELFChangedFields(oldRecord, newRecord *domain.GLEIFEntityLegalForm) domain.JSONBString {
+	changes := make(map[string]map[string]string)
+	if oldRecord == nil {
+		return "{}"
+	}
+
+	add := func(field, oldValue, newValue string) {
+		if strings.TrimSpace(oldValue) == strings.TrimSpace(newValue) {
+			return
+		}
+		changes[field] = map[string]string{"old": oldValue, "new": newValue}
+	}
+
+	add("entity_legal_form_name", oldRecord.EntityLegalFormName, newRecord.EntityLegalFormName)
+	add("abbreviations", oldRecord.Abbreviations, newRecord.Abbreviations)
+	add("language_code", oldRecord.LanguageCode, newRecord.LanguageCode)
+	add("country_of_formation", oldRecord.CountryOfFormation, newRecord.CountryOfFormation)
+	add("country_subdivision_of_formation", oldRecord.CountrySubdivisionOfFormation, newRecord.CountrySubdivisionOfFormation)
+	add("status", oldRecord.Status, newRecord.Status)
+
+	if len(changes) == 0 {
+		return "{}"
+	}
+	body, err := json.Marshal(changes)
+	if err != nil {
+		return "{}"
+	}
+	return domain.JSONBString(string(body))
+}
+
+func buildELFAuditRecord(oldRecord, newRecord *domain.GLEIFEntityLegalForm, action string) *domain.GLEIFEntityLegalFormAudit {
+	audit := &domain.GLEIFEntityLegalFormAudit{
+		ELFCode:        strings.TrimSpace(newRecord.ELFCode),
+		Action:         action,
+		RecordSnapshot: marshalELFRecordSnapshot(newRecord),
+		ChangedFields:  buildELFChangedFields(oldRecord, newRecord),
+		ChangedBy:      "gleif_sync",
+	}
+	if oldRecord != nil {
+		audit.ELFVariantID = &oldRecord.ID
+	}
+	if oldRecord == nil {
+		audit.ChangedFields = "{}"
+	}
+	return audit
+}
+
+func marshalELFRecordSnapshot(record *domain.GLEIFEntityLegalForm) domain.JSONBString {
+	body, err := json.Marshal(map[string]string{
+		"elf_code":                         strings.TrimSpace(record.ELFCode),
+		"entity_legal_form_name":           strings.TrimSpace(record.EntityLegalFormName),
+		"abbreviations":                    strings.TrimSpace(record.Abbreviations),
+		"language_code":                    strings.TrimSpace(record.LanguageCode),
+		"country_of_formation":             strings.TrimSpace(record.CountryOfFormation),
+		"country_subdivision_of_formation": strings.TrimSpace(record.CountrySubdivisionOfFormation),
+		"status":                           strings.ToUpper(strings.TrimSpace(record.Status)),
+	})
+	if err != nil {
+		return "{}"
+	}
+	return domain.JSONBString(string(body))
 }
 
 func firstNonEmpty(values ...string) string {

--- a/backend/internal/service/gleif_reference_service.go
+++ b/backend/internal/service/gleif_reference_service.go
@@ -679,16 +679,24 @@ func (s *gleifReferenceService) SyncEntityLegalForms() error {
 		auditRecords = append(auditRecords, buildELFAuditRecord(existing, &decommissioned, "UPDATE"))
 	}
 
+	// Build a deduplicated upsert slice from incomingByKey so that two CSV rows
+	// sharing the same 3-col key cannot land in the same batch and trigger
+	// "ON CONFLICT DO UPDATE command cannot affect row a second time".
+	upsertRecords := make([]*domain.GLEIFEntityLegalForm, 0, len(incomingByKey))
+	for _, rec := range incomingByKey {
+		upsertRecords = append(upsertRecords, rec)
+	}
+
 	if err := s.elfRepo.DeactivateAll(); err != nil {
 		return fmt.Errorf("deactivate entity legal forms: %w", err)
 	}
 
-	for i := 0; i < len(records); i += gleifBatchSize {
+	for i := 0; i < len(upsertRecords); i += gleifBatchSize {
 		end := i + gleifBatchSize
-		if end > len(records) {
-			end = len(records)
+		if end > len(upsertRecords) {
+			end = len(upsertRecords)
 		}
-		if err := s.elfRepo.Upsert(records[i:end]); err != nil {
+		if err := s.elfRepo.Upsert(upsertRecords[i:end]); err != nil {
 			return fmt.Errorf("upsert entity legal forms batch: %w", err)
 		}
 	}
@@ -1231,10 +1239,16 @@ func elfVariantKey(record *domain.GLEIFEntityLegalForm) string {
 	if record == nil {
 		return ""
 	}
+	// Prefer subdivision; fall back to country to avoid empty middle segment collapsing
+	// unrelated variants onto the same key when subdivision is absent in the source CSV.
+	subdivision := strings.ToUpper(strings.TrimSpace(record.CountrySubdivisionOfFormation))
+	if subdivision == "" {
+		subdivision = strings.ToUpper(strings.TrimSpace(record.CountryOfFormation))
+	}
 	return strings.Join([]string{
 		strings.TrimSpace(record.ELFCode),
 		strings.ToLower(strings.TrimSpace(record.LanguageCode)),
-		strings.ToUpper(strings.TrimSpace(record.CountrySubdivisionOfFormation)),
+		subdivision,
 	}, "|")
 }
 

--- a/backend/internal/service/gleif_reference_service_test.go
+++ b/backend/internal/service/gleif_reference_service_test.go
@@ -37,6 +37,7 @@ var _ repository.GLEIFRegistrationAuthorityRepository = (*stubRARepo)(nil)
 type stubELFRepo struct {
 	deactivateCalled int
 	upserted         []*domain.GLEIFEntityLegalForm
+	findAllForSync   []*domain.GLEIFEntityLegalForm
 }
 
 func (r *stubELFRepo) Upsert(records []*domain.GLEIFEntityLegalForm) error {
@@ -47,10 +48,24 @@ func (r *stubELFRepo) Count() (int64, error) { return int64(len(r.upserted)), ni
 func (r *stubELFRepo) FindAll(_ int, _ int) ([]*domain.GLEIFEntityLegalForm, error) {
 	return r.upserted, nil
 }
+func (r *stubELFRepo) FindAllForSync() ([]*domain.GLEIFEntityLegalForm, error) {
+	return r.findAllForSync, nil
+}
 func (r *stubELFRepo) FindByELFCode(_ string) (*domain.GLEIFEntityLegalForm, error) { return nil, nil }
 func (r *stubELFRepo) DeactivateAll() error                                         { r.deactivateCalled++; return nil }
 
 var _ repository.GLEIFEntityLegalFormRepository = (*stubELFRepo)(nil)
+
+type stubELFAuditRepo struct {
+	upserted []*domain.GLEIFEntityLegalFormAudit
+}
+
+func (r *stubELFAuditRepo) UpsertAuditRecords(records []*domain.GLEIFEntityLegalFormAudit) error {
+	r.upserted = append(r.upserted, records...)
+	return nil
+}
+
+var _ repository.GLEIFEntityLegalFormAuditRepository = (*stubELFAuditRepo)(nil)
 
 type stubRoleRepo struct {
 	deactivateCalled int
@@ -98,14 +113,20 @@ func newTestGLEIFSvc(
 	elfRepo repository.GLEIFEntityLegalFormRepository,
 	roleRepo repository.GLEIFOrganizationalRoleRepository,
 	jurRepo repository.GLEIFLegalJurisdictionRepository,
+	auditRepo ...repository.GLEIFEntityLegalFormAuditRepository,
 ) *gleifReferenceService {
+	elfAuditRepo := repository.GLEIFEntityLegalFormAuditRepository(&stubELFAuditRepo{})
+	if len(auditRepo) > 0 && auditRepo[0] != nil {
+		elfAuditRepo = auditRepo[0]
+	}
 	return &gleifReferenceService{
-		raRepo:   raRepo,
-		elfRepo:  elfRepo,
-		roleRepo: roleRepo,
-		jurRepo:  jurRepo,
-		client:   client,
-		urls:     DefaultGLEIFReferenceURLs(),
+		raRepo:       raRepo,
+		elfRepo:      elfRepo,
+		elfAuditRepo: elfAuditRepo,
+		roleRepo:     roleRepo,
+		jurRepo:      jurRepo,
+		client:       client,
+		urls:         DefaultGLEIFReferenceURLs(),
 	}
 }
 
@@ -605,5 +626,61 @@ func TestFetchRegistrationAuthoritiesFromAPI_PaginatesAndMaps(t *testing.T) {
 	}
 	if records[1].OrganizationName != "Org 2" {
 		t.Fatalf("expected fallback organization name Org 2, got %q", records[1].OrganizationName)
+	}
+}
+
+func TestSyncEntityLegalForms_WritesAuditForCreateUpdateAndDecommission(t *testing.T) {
+	elfCSV := "ELF Code\tCountry\tSubdivision\tLegalFormName\tAbbreviation\tStatus\n" +
+		"2HBR\tDE\t\tGesellschaft mit beschrankter Haftung\tGmbH\tACTIVE\n" +
+		"9ZZZ\tUS\t\tLimited Liability Company\tLLC\tACTIVE\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(elfCSV))
+	}))
+	defer srv.Close()
+
+	elfRepo := &stubELFRepo{findAllForSync: []*domain.GLEIFEntityLegalForm{
+		{ELFCode: "2HBR", CountryOfFormation: "DE", EntityLegalFormName: "GmbH", Status: "ACTIVE"},
+		{ELFCode: "7AAA", CountryOfFormation: "GB", EntityLegalFormName: "Old Form", Status: "ACTIVE"},
+	}}
+	auditRepo := &stubELFAuditRepo{}
+
+	svc := newTestGLEIFSvc(srv.Client(), &stubRARepo{}, elfRepo, &stubRoleRepo{}, &stubJurRepo{}, auditRepo)
+	svc.urls.EntityLegalForms = srv.URL
+
+	err := svc.SyncEntityLegalForms()
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if elfRepo.deactivateCalled != 1 {
+		t.Fatalf("expected deactivate called once, got %d", elfRepo.deactivateCalled)
+	}
+	if len(elfRepo.upserted) != 2 {
+		t.Fatalf("expected 2 upserted records, got %d", len(elfRepo.upserted))
+	}
+	// With key=(elf_code, language_code, country_subdivision_of_formation):
+	// - 2HBR matches pre-sync record → UPDATE (entity_legal_form_name changed)
+	// - 9ZZZ is new → CREATE
+	// - 7AAA was in pre-sync but absent from CSV → UPDATE (decommission)
+	if len(auditRepo.upserted) != 3 {
+		t.Fatalf("expected 3 audit records (1 update + 1 create + 1 decommission), got %d", len(auditRepo.upserted))
+	}
+
+	createCount := 0
+	updateCount := 0
+	for _, audit := range auditRepo.upserted {
+		switch audit.Action {
+		case "CREATE":
+			createCount++
+		case "UPDATE":
+			updateCount++
+		}
+	}
+	if createCount != 1 {
+		t.Fatalf("expected one CREATE audit record (9ZZZ), got %d", createCount)
+	}
+	if updateCount != 2 {
+		t.Fatalf("expected two UPDATE audit records (2HBR field change + 7AAA decommission), got %d", updateCount)
 	}
 }

--- a/backend/internal/service/service.go
+++ b/backend/internal/service/service.go
@@ -48,6 +48,7 @@ func NewServices(repos *repository.Repositories, db *gorm.DB, leiDataDir string,
 		GLEIFReference: NewGLEIFReferenceService(
 			repos.GLEIFRegistrationAuthority,
 			repos.GLEIFEntityLegalForm,
+			repos.GLEIFEntityLegalFormAudit,
 			repos.GLEIFOrganizationalRole,
 			repos.GLEIFLegalJurisdiction,
 			leiDataDir,

--- a/backend/migrations/000061_fix_gleif_elf_variant_constraint_and_audit.down.sql
+++ b/backend/migrations/000061_fix_gleif_elf_variant_constraint_and_audit.down.sql
@@ -1,0 +1,9 @@
+-- Revert ELF current-state uniqueness and remove ELF audit table.
+
+DROP TABLE IF EXISTS lei_raw.gleif_entity_legal_forms_audit;
+
+DROP INDEX IF EXISTS lei_raw.ux_gleif_elf_variant;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_gleif_elf_variant
+    ON lei_raw.gleif_entity_legal_forms
+    (elf_code, language_code, country_of_formation, country_subdivision_of_formation, entity_legal_form_name, status);

--- a/backend/migrations/000061_fix_gleif_elf_variant_constraint_and_audit.up.sql
+++ b/backend/migrations/000061_fix_gleif_elf_variant_constraint_and_audit.up.sql
@@ -19,6 +19,15 @@ CREATE INDEX IF NOT EXISTS idx_gleif_elf_audit_elf_code
 CREATE INDEX IF NOT EXISTS idx_gleif_elf_audit_created_at
     ON lei_raw.gleif_entity_legal_forms_audit (created_at DESC);
 
+CREATE INDEX IF NOT EXISTS idx_gleif_elf_audit_elf_variant_id
+    ON lei_raw.gleif_entity_legal_forms_audit (elf_variant_id);
+
+CREATE INDEX IF NOT EXISTS idx_gleif_elf_audit_action
+    ON lei_raw.gleif_entity_legal_forms_audit (action);
+
+CREATE INDEX IF NOT EXISTS idx_gleif_elf_audit_variant_action_created_at
+    ON lei_raw.gleif_entity_legal_forms_audit (elf_variant_id, action, created_at DESC);
+
 COMMENT ON TABLE lei_raw.gleif_entity_legal_forms_audit IS
 'Full audit history for lei_raw.gleif_entity_legal_forms lifecycle changes. Records CREATE/UPDATE transitions with JSONB snapshot and changed-fields diff.';
 

--- a/backend/migrations/000061_fix_gleif_elf_variant_constraint_and_audit.up.sql
+++ b/backend/migrations/000061_fix_gleif_elf_variant_constraint_and_audit.up.sql
@@ -1,0 +1,55 @@
+-- Fix ELF variant uniqueness to represent current state per variant key.
+-- Also add audit history table for ELF lifecycle transitions.
+
+CREATE TABLE IF NOT EXISTS lei_raw.gleif_entity_legal_forms_audit (
+    id UUID NOT NULL DEFAULT GEN_RANDOM_UUID(),
+    elf_variant_id UUID,
+    elf_code VARCHAR(10) NOT NULL,
+    action VARCHAR(20) NOT NULL,
+    record_snapshot JSONB NOT NULL,
+    changed_fields JSONB,
+    changed_by VARCHAR(100) NOT NULL DEFAULT 'system',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT pk_gleif_entity_legal_forms_audit PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_gleif_elf_audit_elf_code
+    ON lei_raw.gleif_entity_legal_forms_audit (elf_code);
+
+CREATE INDEX IF NOT EXISTS idx_gleif_elf_audit_created_at
+    ON lei_raw.gleif_entity_legal_forms_audit (created_at DESC);
+
+COMMENT ON TABLE lei_raw.gleif_entity_legal_forms_audit IS
+'Full audit history for lei_raw.gleif_entity_legal_forms lifecycle changes. Records CREATE/UPDATE transitions with JSONB snapshot and changed-fields diff.';
+
+COMMENT ON COLUMN lei_raw.gleif_entity_legal_forms_audit.elf_variant_id IS
+'UUID of the existing gleif_entity_legal_forms row when available. Null for brand new variants before insert.';
+
+-- Remove duplicate rows created by status-in-key uniqueness.
+-- Keep one row per variant key, preferring ACTIVE then most recently updated row.
+WITH ranked AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                elf_code,
+                language_code,
+                country_subdivision_of_formation
+            ORDER BY
+                CASE WHEN status = 'ACTIVE' THEN 0 ELSE 1 END,
+                updated_at DESC,
+                created_at DESC,
+                id DESC
+        ) AS rn
+    FROM lei_raw.gleif_entity_legal_forms
+)
+DELETE FROM lei_raw.gleif_entity_legal_forms t
+USING ranked r
+WHERE t.id = r.id
+  AND r.rn > 1;
+
+DROP INDEX IF EXISTS lei_raw.ux_gleif_elf_variant;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_gleif_elf_variant
+    ON lei_raw.gleif_entity_legal_forms
+    (elf_code, language_code, country_subdivision_of_formation);


### PR DESCRIPTION
## Summary

Fixes the daily GLEIF ELF (Entity Legal Form) reference sync failing with:

```
ERROR: duplicate key value violates unique constraint "ux_gleif_elf_variant" (SQLSTATE 23505)
```

Closes #349

## Root Cause

Migration `000059` defined the unique index `ux_gleif_elf_variant` with `status` as part
of the composite key:

```
(elf_code, language_code, country_of_formation, country_subdivision_of_formation,
 entity_legal_form_name, status)
```

The sync pattern is DeactivateAll (ACTIVE→DECOMMISSIONED) then Upsert (CSV rows = ACTIVE).
Because `status` was in the key, each variant accumulated two rows — one ACTIVE and one
DECOMMISSIONED. On the next run, DeactivateAll tried to flip the ACTIVE row to DECOMMISSIONED
but an identical DECOMMISSIONED row already existed → constraint violation.

## Fix

### Migration 000061

- Deduplicates existing rows (keeps the ACTIVE-preferred, latest `updated_at` winner per
  3-col key) — reduces 7,792 rows to 4,001 (eliminating 3,789 ghost duplicates)
- Drops the old 6-col index and creates a new **3-col unique index**:
  `(elf_code, language_code, country_subdivision_of_formation)`
- Creates `lei_raw.gleif_entity_legal_forms_audit` table for change history

**Why 3 columns?**  `entity_legal_form_name` is just the human-readable label for `elf_code`
(redundant). `country_of_formation` is always subsumed by `country_subdivision_of_formation`
which is always populated and more granular.

### Service changes

- `Upsert()` conflict columns updated to the 3-col key; mutable fields
  (`entity_legal_form_name`, `abbreviations`, `country_of_formation`, `status`) moved to
  `DO UPDATE SET`
- Added `FindAllForSync()` to load pre-sync state for diffing
- `SyncEntityLegalForms()` rewritten to diff pre/post state and write audit records
- Added `GLEIFEntityLegalFormAuditRepository` with bulk-insert `UpsertAuditRecords()`

## Before / After (axiom_main, version 60 → 61)

| Metric | Before | After |
|---|---|---|
| Total ELF rows | 7,792 | **4,001** |
| ACTIVE rows | 3,790 | 3,789 |
| DECOMMISSIONED rows | 4,002 | **212** |
| Duplicate 3-col variant keys | **3,789** | **0** |
| Unique index columns | 6 | **3** |

## Testing

- Unit test `TestSyncEntityLegalForms_WritesAuditForCreateUpdateAndDecommission` covers:
  - UPDATE (name change on existing active variant)
  - CREATE (new variant not in pre-sync state)
  - UPDATE + DECOMMISSION (variant present pre-sync but absent from CSV)
- ON CONFLICT SQL verified directly against the migrated DB — no `SQLSTATE 42P10`
- Status flip ACTIVE→DECOMMISSIONED on same 3-col key produces exactly 1 row (was 2)
- `go test ./...` passes in the worktree