### PR TITLE
fix: persist last LEI run summary after completion

### DIFF
--- a/backend/internal/service/lei_batch_resolve.go
+++ b/backend/internal/service/lei_batch_resolve.go
@@ -29,7 +29,7 @@ func (s *leiService) batchResolveOpenProcessingFailures(jobType string, naturalK
 	}
 
 	if err := s.repo.BatchResolveOpenProcessingFailures(
-		normalizeProcessingJobType(jobType),
+		normalizeProcessingFailureJobType(jobType),
 		normalizedKeys,
 		sourceFileID,
 		"Resolved by subsequent successful upsert",

--- a/backend/internal/service/lei_progress_test.go
+++ b/backend/internal/service/lei_progress_test.go
@@ -239,6 +239,60 @@ func TestUpdateProcessingStatus_Level1JobPreservesMessageWhenCompleted(t *testin
 	}
 }
 
+func TestUpdateProcessingStatus_Level2IdleWithEmptyMessageKeepsExistingProgress(t *testing.T) {
+	stub := &progressMsgRepoStub{
+		statusToReturn: &domain.FileProcessingStatus{
+			ID:              uuid.New(),
+			JobType:         "LEVEL2_RR",
+			Status:          "RUNNING",
+			ProgressMessage: `{"kind":"level2-progress","evaluated":470868,"upserted":1464,"unchanged":469400,"failed":4,"total":470868}`,
+		},
+	}
+	svc := newProgressMsgService(stub)
+
+	status := &domain.FileProcessingStatus{
+		ID:              uuid.New(),
+		JobType:         "LEVEL2_RR",
+		Status:          "IDLE",
+		ProgressMessage: "",
+		ErrorMessage:    "",
+	}
+
+	if err := svc.UpdateProcessingStatus(status); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stub.capturedMessage, `"kind":"level2-progress"`) {
+		t.Fatalf("expected existing level2 progress message to be preserved, got %q", stub.capturedMessage)
+	}
+}
+
+func TestUpdateProcessingStatus_Level1IdleWithErrorDoesNotReuseExistingProgress(t *testing.T) {
+	stub := &progressMsgRepoStub{
+		statusToReturn: &domain.FileProcessingStatus{
+			ID:              uuid.New(),
+			JobType:         "DAILY_FULL",
+			Status:          "RUNNING",
+			ProgressMessage: `{"kind":"level1-progress","evaluated":1000,"upserted":200,"unchanged":800,"failed":0,"total":1000}`,
+		},
+	}
+	svc := newProgressMsgService(stub)
+
+	status := &domain.FileProcessingStatus{
+		ID:              uuid.New(),
+		JobType:         "DAILY_FULL",
+		Status:          "FAILED",
+		ProgressMessage: "",
+		ErrorMessage:    "network timeout",
+	}
+
+	if err := svc.UpdateProcessingStatus(status); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stub.capturedMessage != "" {
+		t.Fatalf("FAILED update with error should not reuse previous progress payload, got %q", stub.capturedMessage)
+	}
+}
+
 func TestBuildLevel1ProgressMessage(t *testing.T) {
 	raw := buildLevel1ProgressMessage(470651, 470651, 116, 4)
 	if raw == "" {

--- a/backend/internal/service/lei_progress_test.go
+++ b/backend/internal/service/lei_progress_test.go
@@ -266,7 +266,7 @@ func TestUpdateProcessingStatus_Level2IdleWithEmptyMessageKeepsExistingProgress(
 	}
 }
 
-func TestUpdateProcessingStatus_Level1IdleWithErrorDoesNotReuseExistingProgress(t *testing.T) {
+func TestUpdateProcessingStatus_Level1FailedWithErrorDoesNotReuseExistingProgress(t *testing.T) {
 	stub := &progressMsgRepoStub{
 		statusToReturn: &domain.FileProcessingStatus{
 			ID:              uuid.New(),

--- a/backend/internal/service/lei_service.go
+++ b/backend/internal/service/lei_service.go
@@ -829,7 +829,8 @@ func (s *leiService) processRecordsArray(decoder *json.Decoder, sourceFile *doma
 	var totalUpdated int
 	shouldProcess := resumeFromLEI == ""
 	var lastProcessedLEI string
-	jobType := normalizeProcessingJobType(sourceFile.JobType)
+	statusJobType := normalizeProcessingJobType(sourceFile.JobType)
+	failureJobType := normalizeProcessingFailureJobType(sourceFile.JobType)
 
 	// Track checkpoint value separately from session progress
 	checkpointProcessed := 0
@@ -952,7 +953,7 @@ func (s *leiService) processRecordsArray(decoder *json.Decoder, sourceFile *doma
 				Str("last_lei", batch[len(batch)-1].LEI).
 				Msg("CRITICAL: Failed to batch upsert LEI records")
 			batchErr := fmt.Errorf("batch upsert of %d LEI records failed: %w", len(batch), err)
-			s.recordProcessingFailure(jobType, &sourceFile.ID, "UPSERT", "", nil, batchErr)
+			s.recordProcessingFailure(failureJobType, &sourceFile.ID, "UPSERT", "", nil, batchErr)
 			failedRecords += len(batch)
 			// Return error to stop processing
 			return fmt.Errorf("batch upsert failed: %w", err)
@@ -961,7 +962,7 @@ func (s *leiService) processRecordsArray(decoder *json.Decoder, sourceFile *doma
 			for _, r := range batch {
 				naturalKeys = append(naturalKeys, r.LEI)
 			}
-			s.batchResolveOpenProcessingFailures(jobType, naturalKeys, &sourceFile.ID)
+			s.batchResolveOpenProcessingFailures(failureJobType, naturalKeys, &sourceFile.ID)
 
 			// Accumulate actual DB write outcomes.
 			totalCreated += created
@@ -996,7 +997,7 @@ func (s *leiService) processRecordsArray(decoder *json.Decoder, sourceFile *doma
 			}
 
 			totalUpserted := totalCreated + totalUpdated
-			s.persistLevel1ProgressMessage(jobType, progressTotalRecords, cumulativeProcessed, totalUpserted, failedRecords)
+			s.persistLevel1ProgressMessage(statusJobType, progressTotalRecords, cumulativeProcessed, totalUpserted, failedRecords)
 
 			log.Info().
 				Int("total_scanned", scannedRecords).
@@ -1025,13 +1026,12 @@ func (s *leiService) processRecordsArray(decoder *json.Decoder, sourceFile *doma
 		recordCount++
 		var jsonRecord LEIJSONRecord
 		if err := decoder.Decode(&jsonRecord); err != nil {
-			jobType := normalizeProcessingJobType(sourceFile.JobType)
 			if isTerminalJSONDecodeError(err) {
 				log.Error().
 					Err(err).
 					Int("record_number", recordCount).
 					Msg("Terminating LEI JSON processing due to malformed or truncated JSON payload")
-				s.recordProcessingFailure(jobType, &sourceFile.ID, "DECODE", "", nil, err)
+				s.recordProcessingFailure(failureJobType, &sourceFile.ID, "DECODE", "", nil, err)
 				return fmt.Errorf("terminal JSON decode error at record %d: %w", recordCount, err)
 			}
 
@@ -1039,7 +1039,7 @@ func (s *leiService) processRecordsArray(decoder *json.Decoder, sourceFile *doma
 				Err(err).
 				Int("record_number", recordCount).
 				Msg("Failed to decode LEI JSON record")
-			s.recordProcessingFailure(jobType, &sourceFile.ID, "DECODE", "", nil, err)
+			s.recordProcessingFailure(failureJobType, &sourceFile.ID, "DECODE", "", nil, err)
 			failedRecords++
 			continue
 		}
@@ -1072,7 +1072,7 @@ func (s *leiService) processRecordsArray(decoder *json.Decoder, sourceFile *doma
 				Str("invalid_lei", record.LEI).
 				Int("record_number", recordCount).
 				Msg("Skipping record with invalid LEI code")
-			s.recordProcessingFailure(normalizeProcessingJobType(sourceFile.JobType), &sourceFile.ID, "MAP", record.LEI, &jsonRecord, fmt.Errorf("invalid LEI code: %s", record.LEI))
+			s.recordProcessingFailure(failureJobType, &sourceFile.ID, "MAP", record.LEI, &jsonRecord, fmt.Errorf("invalid LEI code: %s", record.LEI))
 			failedRecords++
 			continue
 		}
@@ -1110,7 +1110,7 @@ func (s *leiService) processRecordsArray(decoder *json.Decoder, sourceFile *doma
 	}
 
 	totalUpserted := totalCreated + totalUpdated
-	s.persistLevel1ProgressMessage(jobType, progressTotalRecords, cumulativeProcessed, totalUpserted, failedRecords)
+	s.persistLevel1ProgressMessage(statusJobType, progressTotalRecords, cumulativeProcessed, totalUpserted, failedRecords)
 
 	if processedRecords > 0 && totalCreated == 0 && totalUpdated == 0 && failedRecords == 0 {
 		log.Warn().
@@ -1191,7 +1191,7 @@ func (s *leiService) recordProcessingFailure(
 ) {
 	persistProcessingFailure(
 		s.repo,
-		normalizeProcessingJobType(jobType),
+		normalizeProcessingFailureJobType(jobType),
 		sourceFileID,
 		failureStage,
 		normalizeLEICodeValue(naturalKey),

--- a/backend/internal/service/lei_service.go
+++ b/backend/internal/service/lei_service.go
@@ -1695,6 +1695,10 @@ func (s *leiService) GetProcessingStatus(jobType string) (*domain.FileProcessing
 // UpdateProcessingStatus updates processing status
 func (s *leiService) UpdateProcessingStatus(status *domain.FileProcessingStatus) error {
 	if status != nil {
+		trimmedJobType := strings.TrimSpace(status.JobType)
+		trimmedProgressMessage := strings.TrimSpace(status.ProgressMessage)
+		trimmedErrorMessage := strings.TrimSpace(status.ErrorMessage)
+
 		if status.JobType != "" {
 			status.JobLabel = domain.JobTypeDisplayName(status.JobType)
 		}
@@ -1706,6 +1710,21 @@ func (s *leiService) UpdateProcessingStatus(status *domain.FileProcessingStatus)
 		if status.CurrentSourceFileID == nil {
 			status.CurrentSourceFile = nil
 		}
+
+		// Callers often update terminal state (IDLE/COMPLETED) using a status struct that
+		// does not carry ProgressMessage, which would otherwise overwrite persisted
+		// per-run JSON stats with an empty value.
+		// Preserve the existing message for successful terminal updates of jobs that opt in.
+		if status.Status != "RUNNING" && trimmedJobType != "" && trimmedProgressMessage == "" && trimmedErrorMessage == "" && shouldPreserveProgressMessage(trimmedJobType) {
+			existing, err := s.repo.FindProcessingStatus(trimmedJobType)
+			if err == nil && existing != nil {
+				existingProgressMessage := strings.TrimSpace(existing.ProgressMessage)
+				if existingProgressMessage != "" {
+					status.ProgressMessage = existingProgressMessage
+				}
+			}
+		}
+
 		// Some jobs persist machine-readable post-completion stats in ProgressMessage.
 		// Preserve these payloads outside RUNNING so UI can render accurate final summaries.
 		if status.Status != "RUNNING" && !shouldPreserveProgressMessage(status.JobType) {

--- a/backend/internal/service/lei_service_test.go
+++ b/backend/internal/service/lei_service_test.go
@@ -455,10 +455,10 @@ func TestNormalizeProcessingJobType(t *testing.T) {
 		want  string
 	}{
 		// Level-1 aliases
-		{input: "DAILY_FULL", want: "LEVEL1_FULL"},
-		{input: "LEVEL1_FULL", want: "LEVEL1_FULL"},
-		{input: "DAILY_DELTA", want: "LEVEL1_DELTA"},
-		{input: "LEVEL1_DELTA", want: "LEVEL1_DELTA"},
+		{input: "DAILY_FULL", want: "DAILY_FULL"},
+		{input: "LEVEL1_FULL", want: "DAILY_FULL"},
+		{input: "DAILY_DELTA", want: "DAILY_DELTA"},
+		{input: "LEVEL1_DELTA", want: "DAILY_DELTA"},
 		// Level-2 pass-throughs
 		{input: "LEVEL2_RR", want: "LEVEL2_RR"},
 		{input: "LEVEL2_REPEX", want: "LEVEL2_REPEX"},
@@ -484,10 +484,10 @@ func TestNormalizeProcessingJobTypePrivateDelegates(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"DAILY_FULL", "LEVEL1_FULL"},
-		{"LEVEL1_FULL", "LEVEL1_FULL"},
-		{"DAILY_DELTA", "LEVEL1_DELTA"},
-		{"LEVEL1_DELTA", "LEVEL1_DELTA"},
+		{"DAILY_FULL", "DAILY_FULL"},
+		{"LEVEL1_FULL", "DAILY_FULL"},
+		{"DAILY_DELTA", "DAILY_DELTA"},
+		{"LEVEL1_DELTA", "DAILY_DELTA"},
 		{"LEVEL2_RR", "LEVEL2_RR"},
 		{"LEVEL2_REPEX", "LEVEL2_REPEX"},
 		{"UNKNOWN_TYPE", "UNKNOWN_TYPE"}, // pass-through

--- a/backend/internal/service/lei_service_test.go
+++ b/backend/internal/service/lei_service_test.go
@@ -454,7 +454,7 @@ func TestNormalizeProcessingJobType(t *testing.T) {
 		input string
 		want  string
 	}{
-		// Level-1 aliases
+		// Status-row aliases
 		{input: "DAILY_FULL", want: "DAILY_FULL"},
 		{input: "LEVEL1_FULL", want: "DAILY_FULL"},
 		{input: "DAILY_DELTA", want: "DAILY_DELTA"},
@@ -477,9 +477,37 @@ func TestNormalizeProcessingJobType(t *testing.T) {
 	}
 }
 
+func TestNormalizeProcessingFailureJobType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// Failure-row aliases
+		{input: "DAILY_FULL", want: "LEVEL1_FULL"},
+		{input: "LEVEL1_FULL", want: "LEVEL1_FULL"},
+		{input: "DAILY_DELTA", want: "LEVEL1_DELTA"},
+		{input: "LEVEL1_DELTA", want: "LEVEL1_DELTA"},
+		// Level-2 pass-throughs
+		{input: "LEVEL2_RR", want: "LEVEL2_RR"},
+		{input: "LEVEL2_REPEX", want: "LEVEL2_REPEX"},
+		// Unknown types → empty string
+		{input: "UNKNOWN", want: ""},
+		{input: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := NormalizeProcessingFailureJobType(tt.input)
+			if got != tt.want {
+				t.Fatalf("NormalizeProcessingFailureJobType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeProcessingJobTypePrivateDelegates(t *testing.T) {
-	// The private function must map the same known aliases as the exported one
-	// and pass unknown / Level-2 types through unchanged.
+	// The private function must map the same known aliases as the exported status
+	// normalizer and pass unknown / Level-2 types through unchanged.
 	cases := []struct {
 		input string
 		want  string
@@ -497,6 +525,30 @@ func TestNormalizeProcessingJobTypePrivateDelegates(t *testing.T) {
 		got := normalizeProcessingJobType(c.input)
 		if got != c.want {
 			t.Errorf("normalizeProcessingJobType(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeProcessingFailureJobTypePrivateDelegates(t *testing.T) {
+	// The private function must map the same known aliases as the exported
+	// failure normalizer and pass unknown / Level-2 types through unchanged.
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"DAILY_FULL", "LEVEL1_FULL"},
+		{"LEVEL1_FULL", "LEVEL1_FULL"},
+		{"DAILY_DELTA", "LEVEL1_DELTA"},
+		{"LEVEL1_DELTA", "LEVEL1_DELTA"},
+		{"LEVEL2_RR", "LEVEL2_RR"},
+		{"LEVEL2_REPEX", "LEVEL2_REPEX"},
+		{"UNKNOWN_TYPE", "UNKNOWN_TYPE"}, // pass-through
+		{"", ""},                         // empty → empty
+	}
+	for _, c := range cases {
+		got := normalizeProcessingFailureJobType(c.input)
+		if got != c.want {
+			t.Errorf("normalizeProcessingFailureJobType(%q) = %q, want %q", c.input, got, c.want)
 		}
 	}
 }
@@ -571,9 +623,9 @@ func TestBatchResolveOpenProcessingFailures_Service_ValidKeys(t *testing.T) {
 	if stub.callCount != 1 {
 		t.Fatalf("expected exactly 1 repo call, got %d", stub.callCount)
 	}
-	// Job type must be normalised (DAILY_FULL is already canonical).
-	if stub.calledJobType != "DAILY_FULL" {
-		t.Errorf("expected calledJobType DAILY_FULL, got %q", stub.calledJobType)
+	// Failure job type must keep the Level-1 category.
+	if stub.calledJobType != "LEVEL1_FULL" {
+		t.Errorf("expected calledJobType LEVEL1_FULL, got %q", stub.calledJobType)
 	}
 	// LEI codes must be upper-cased and trimmed.
 	if len(stub.calledKeys) != 2 {

--- a/backend/internal/service/lei_service_test.go
+++ b/backend/internal/service/lei_service_test.go
@@ -571,9 +571,9 @@ func TestBatchResolveOpenProcessingFailures_Service_ValidKeys(t *testing.T) {
 	if stub.callCount != 1 {
 		t.Fatalf("expected exactly 1 repo call, got %d", stub.callCount)
 	}
-	// Job type must be normalised (DAILY_FULL → LEVEL1_FULL).
-	if stub.calledJobType != "LEVEL1_FULL" {
-		t.Errorf("expected calledJobType LEVEL1_FULL, got %q", stub.calledJobType)
+	// Job type must be normalised (DAILY_FULL is already canonical).
+	if stub.calledJobType != "DAILY_FULL" {
+		t.Errorf("expected calledJobType DAILY_FULL, got %q", stub.calledJobType)
 	}
 	// LEI codes must be upper-cased and trimmed.
 	if len(stub.calledKeys) != 2 {

--- a/backend/internal/service/processing_job_type.go
+++ b/backend/internal/service/processing_job_type.go
@@ -23,8 +23,36 @@ func NormalizeProcessingJobType(jobType string) string {
 	}
 }
 
+// NormalizeProcessingFailureJobType maps known aliases to the canonical
+// processing failure job types.
+//
+// Level-1 aliases map to LEVEL1_* so processing failures keep their
+// historical category used by failure resolution paths.
+func NormalizeProcessingFailureJobType(jobType string) string {
+	normalized := strings.ToUpper(strings.TrimSpace(jobType))
+
+	switch normalized {
+	case "LEVEL1_FULL", "DAILY_FULL":
+		return "LEVEL1_FULL"
+	case "LEVEL1_DELTA", "DAILY_DELTA":
+		return "LEVEL1_DELTA"
+	case "LEVEL2_RR", "LEVEL2_REPEX":
+		return normalized
+	default:
+		return ""
+	}
+}
+
 func normalizeProcessingJobType(jobType string) string {
 	canonical := NormalizeProcessingJobType(jobType)
+	if canonical != "" {
+		return canonical
+	}
+	return strings.TrimSpace(jobType)
+}
+
+func normalizeProcessingFailureJobType(jobType string) string {
+	canonical := NormalizeProcessingFailureJobType(jobType)
 	if canonical != "" {
 		return canonical
 	}

--- a/backend/internal/service/processing_job_type.go
+++ b/backend/internal/service/processing_job_type.go
@@ -2,16 +2,20 @@ package service
 
 import "strings"
 
-// NormalizeProcessingJobType maps known Level-1 aliases to canonical names and
-// keeps Level-2 job types unchanged. Unknown values return an empty string.
+// NormalizeProcessingJobType maps known aliases to the canonical processing
+// status job types used by the scheduler/status rows.
+//
+// Level-1 aliases map to DAILY_* so progress updates are written to the same
+// job_type consumed by /api/v1/lei/status/DAILY_FULL and DAILY_DELTA.
+// Level-2 job types pass through unchanged. Unknown values return empty.
 func NormalizeProcessingJobType(jobType string) string {
 	normalized := strings.ToUpper(strings.TrimSpace(jobType))
 
 	switch normalized {
 	case "DAILY_FULL", "LEVEL1_FULL":
-		return "LEVEL1_FULL"
+		return "DAILY_FULL"
 	case "DAILY_DELTA", "LEVEL1_DELTA":
-		return "LEVEL1_DELTA"
+		return "DAILY_DELTA"
 	case "LEVEL2_RR", "LEVEL2_REPEX":
 		return normalized
 	default:


### PR DESCRIPTION
## Summary

Persist last-run LEI summary stats in status rows after job completion so users can see what just happened.

## Problem

During RUNNING, progress counters update correctly. But when jobs transition to terminal states, some callers update status with an empty `ProgressMessage`, which overwrites previously persisted JSON payloads. The UI then shows `-` for Upserted/No Change on the most recent run.

## Changes

- Normalize Level 1 aliases to `DAILY_FULL` / `DAILY_DELTA` so progress updates land on the same job types polled by the UI.
- In `UpdateProcessingStatus`, preserve existing `progress_message` for successful non-running updates when:
  - job type supports preserved summaries,
  - incoming `ProgressMessage` is empty,
  - incoming `ErrorMessage` is empty.
- Keep failure semantics unchanged: do not reuse prior summary when `ErrorMessage` is present.
- Add regression tests for:
  - normalization behavior,
  - preserving Level 2 summary on IDLE update with empty incoming message,
  - not preserving on FAILED update with error.

## Validation

- `go test ./internal/service -run "TestNormalizeProcessingJobType|TestNormalizeProcessingJobTypePrivateDelegates|TestUpdateProcessingStatus" -v`
- Live verification on `LEVEL2_RR`:
  - RUNNING: progress payload present
  - IDLE (after completion): payload still present (no longer wiped)

## Notes

No schema changes.