### PR TITLE
fix: registration status badge — no wrapping, tooltips, detail panel layout

### DIFF
--- a/frontend/app/components/LEIAuditHistoryModal.tsx
+++ b/frontend/app/components/LEIAuditHistoryModal.tsx
@@ -327,7 +327,10 @@ function SnapshotValue({ fieldKey, value, snapshot, showCodes = true, countryByC
       muted: 'theme-subtle',
     }
     return (
-      <span className={`inline-block px-2 py-1 text-xs rounded ${variantStyles[regStatusPresentation.variant]}`}>
+      <span
+        title={regStatusPresentation.tooltip}
+        className={`inline-block whitespace-nowrap px-2 py-1 text-xs rounded ${variantStyles[regStatusPresentation.variant]}`}
+      >
         {regStatusPresentation.label}
       </span>
     )

--- a/frontend/app/lei-records/null-utils.test.ts
+++ b/frontend/app/lei-records/null-utils.test.ts
@@ -79,6 +79,7 @@ describe('getRegistrationStatusBadgePresentation', () => {
     const result = getRegistrationStatusBadgePresentation('ISSUED')
     expect(result).toEqual({
       label: 'ISSUED',
+      tooltip: 'Registration is active and valid',
       variant: 'success',
     })
   })
@@ -87,6 +88,7 @@ describe('getRegistrationStatusBadgePresentation', () => {
     const result = getRegistrationStatusBadgePresentation('LAPSED')
     expect(result).toEqual({
       label: 'Lapsed',
+      tooltip: 'Renewal is overdue — this registration is no longer active',
       variant: 'destructive',
     })
   })
@@ -95,6 +97,7 @@ describe('getRegistrationStatusBadgePresentation', () => {
     const result = getRegistrationStatusBadgePresentation('RETIRED')
     expect(result).toEqual({
       label: 'Retired',
+      tooltip: 'Registration has been permanently retired',
       variant: 'destructive',
     })
   })
@@ -103,6 +106,7 @@ describe('getRegistrationStatusBadgePresentation', () => {
     const result = getRegistrationStatusBadgePresentation('ANNULLED')
     expect(result).toEqual({
       label: 'Annulled',
+      tooltip: 'Registration has been annulled and is considered invalid',
       variant: 'destructive',
     })
   })
@@ -111,6 +115,7 @@ describe('getRegistrationStatusBadgePresentation', () => {
     const result = getRegistrationStatusBadgePresentation('DUPLICATE')
     expect(result).toEqual({
       label: 'Duplicate',
+      tooltip: 'A duplicate superseded by another active registration',
       variant: 'destructive',
     })
   })
@@ -119,6 +124,7 @@ describe('getRegistrationStatusBadgePresentation', () => {
     const result = getRegistrationStatusBadgePresentation('PENDING_TRANSFER')
     expect(result).toEqual({
       label: 'Pending Transfer',
+      tooltip: 'Registration is being transferred to another operator',
       variant: 'warning',
     })
   })
@@ -127,6 +133,7 @@ describe('getRegistrationStatusBadgePresentation', () => {
     const result = getRegistrationStatusBadgePresentation('PENDING_ARCHIVAL')
     expect(result).toEqual({
       label: 'Pending Archival',
+      tooltip: 'Registration is pending archival',
       variant: 'warning',
     })
   })
@@ -135,6 +142,7 @@ describe('getRegistrationStatusBadgePresentation', () => {
     const result = getRegistrationStatusBadgePresentation('UNKNOWN_STATUS')
     expect(result).toEqual({
       label: 'Unknown Status',
+      tooltip: 'Unknown registration status',
       variant: 'muted',
     })
   })
@@ -143,6 +151,7 @@ describe('getRegistrationStatusBadgePresentation', () => {
     const result = getRegistrationStatusBadgePresentation('issued')
     expect(result).toEqual({
       label: 'ISSUED',
+      tooltip: 'Registration is active and valid',
       variant: 'success',
     })
   })
@@ -150,10 +159,12 @@ describe('getRegistrationStatusBadgePresentation', () => {
   it('handles empty string', () => {
     const result = getRegistrationStatusBadgePresentation('')
     expect(result.variant).toBe('muted')
+    expect(result.tooltip).toBe('Unknown registration status')
   })
 
   it('handles null value', () => {
     const result = getRegistrationStatusBadgePresentation(null)
     expect(result.variant).toBe('muted')
+    expect(result.tooltip).toBe('Unknown registration status')
   })
 })

--- a/frontend/app/lei-records/null-utils.ts
+++ b/frontend/app/lei-records/null-utils.ts
@@ -48,15 +48,27 @@ export function getStatusBadgePresentation(value: unknown): { label: string; isA
 
 export type RegistrationStatusVariant = 'success' | 'destructive' | 'warning' | 'muted'
 
+const REGISTRATION_STATUS_TOOLTIPS: Record<string, string> = {
+  ISSUED: 'Registration is active and valid',
+  LAPSED: 'Renewal is overdue — this registration is no longer active',
+  RETIRED: 'Registration has been permanently retired',
+  ANNULLED: 'Registration has been annulled and is considered invalid',
+  DUPLICATE: 'A duplicate superseded by another active registration',
+  PENDING_TRANSFER: 'Registration is being transferred to another operator',
+  PENDING_ARCHIVAL: 'Registration is pending archival',
+}
+
 export function getRegistrationStatusBadgePresentation(value: unknown): {
   label: string
+  tooltip: string
   variant: RegistrationStatusVariant
 } {
   const rawValue = String(value || '').toUpperCase().trim()
+  const tooltip = REGISTRATION_STATUS_TOOLTIPS[rawValue] ?? 'Unknown registration status'
 
   // Active status
   if (rawValue === 'ISSUED') {
-    return { label: 'ISSUED', variant: 'success' }
+    return { label: 'ISSUED', tooltip, variant: 'success' }
   }
 
   // Invalid/lapsed statuses
@@ -66,16 +78,16 @@ export function getRegistrationStatusBadgePresentation(value: unknown): {
     rawValue === 'ANNULLED' ||
     rawValue === 'DUPLICATE'
   ) {
-    return { label: formatEnumDisplayValue(rawValue), variant: 'destructive' }
+    return { label: formatEnumDisplayValue(rawValue), tooltip, variant: 'destructive' }
   }
 
   // In-transition statuses
   if (rawValue === 'PENDING_TRANSFER' || rawValue === 'PENDING_ARCHIVAL') {
-    return { label: formatEnumDisplayValue(rawValue), variant: 'warning' }
+    return { label: formatEnumDisplayValue(rawValue), tooltip, variant: 'warning' }
   }
 
   // Unknown/future values - defensive fallback
-  return { label: formatEnumDisplayValue(rawValue), variant: 'muted' }
+  return { label: formatEnumDisplayValue(rawValue), tooltip, variant: 'muted' }
 }
 
 export function formatLEICellValue(value: unknown, key: string): string {

--- a/frontend/app/lei-records/page.tsx
+++ b/frontend/app/lei-records/page.tsx
@@ -1935,7 +1935,10 @@ export default function LEIRecordsPage() {
                                     muted: 'theme-subtle',
                                   }
                                   return (
-                                    <span className={`px-2 py-1 text-xs rounded ${variantStyles[regStatusPresentation.variant]}`}>
+                                    <span
+                                      title={regStatusPresentation.tooltip}
+                                      className={`inline-block whitespace-nowrap px-2 py-1 text-xs rounded ${variantStyles[regStatusPresentation.variant]}`}
+                                    >
                                       {regStatusPresentation.label}
                                     </span>
                                   )
@@ -2488,9 +2491,14 @@ export default function LEIRecordsPage() {
                         muted: 'theme-subtle',
                       }
                       return (
-                        <span className={`inline-block mt-1 px-2 py-1 text-xs rounded ${variantStyles[regStatusPresentation.variant]}`}>
-                          {regStatusPresentation.label}
-                        </span>
+                        <p className="mt-1">
+                          <span
+                            title={regStatusPresentation.tooltip}
+                            className={`inline-block whitespace-nowrap px-2 py-1 text-xs rounded ${variantStyles[regStatusPresentation.variant]}`}
+                          >
+                            {regStatusPresentation.label}
+                          </span>
+                        </p>
                       )
                     })()}
                   </div>


### PR DESCRIPTION
Closes #352 (follow-up to #354)

## What changed

Three small UX improvements to the registration status badges introduced in #354:

### 1. No more wrapping in the summary table
Added \whitespace-nowrap\ to all badge instances so 'Pending Transfer' and 'Pending Archival' never break onto a second line inside the badge.

### 2. Hover tooltips on all badges
Added a \	itle\ attribute (native browser tooltip) explaining each status in plain English:

| Status | Tooltip |
|--------|---------|
| ISSUED | Registration is active and valid |
| LAPSED | Renewal is overdue — this registration is no longer active |
| RETIRED | Registration has been permanently retired |
| ANNULLED | Registration has been annulled and is considered invalid |
| DUPLICATE | A duplicate superseded by another active registration |
| PENDING_TRANSFER | Registration is being transferred to another operator |
| PENDING_ARCHIVAL | Registration is pending archival |

### 3. Detail panel badge position fixed
Badge now renders below the REGISTRATION STATUS label (wrapped in \<p>\) rather than floating inline after it — consistent with all other fields in the Registration Information section.

## Tests
Updated all \getRegistrationStatusBadgePresentation\ tests to assert the new \	ooltip\ field.

## Files changed
- \rontend/app/lei-records/null-utils.ts\ — added \	ooltip\ to helper return value
- \rontend/app/lei-records/page.tsx\ — summary table + detail panel badge tweaks
- \rontend/app/components/LEIAuditHistoryModal.tsx\ — audit modal badge tooltip
- \rontend/app/lei-records/null-utils.test.ts\ — updated test assertions