### PR TITLE
revert: restore main before PR #356

### DIFF
--- a/frontend/app/components/Badge.tsx
+++ b/frontend/app/components/Badge.tsx
@@ -9,7 +9,6 @@ interface BadgeProps {
   shape?: BadgeShape
   mono?: boolean
   className?: string
-  title?: string
 }
 
 const variantClasses: Record<BadgeVariant, string> = {
@@ -34,11 +33,9 @@ export default function Badge({
   shape = 'rounded',
   mono = false,
   className = '',
-  title,
 }: BadgeProps) {
   return (
     <span
-      title={title}
       className={[
         'px-2 py-1 text-xs font-medium',
         variantClasses[variant],

--- a/frontend/app/components/LEIAuditHistoryModal.tsx
+++ b/frontend/app/components/LEIAuditHistoryModal.tsx
@@ -2,10 +2,9 @@
 
 import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Badge from './Badge'
 import CountryFlag from './CountryFlag'
 import { useButtonEmojiMode } from '../lib/useButtonEmojiMode'
-import { getRegistrationStatusBadgePresentation, REGISTRATION_STATUS_BADGE_VARIANT } from '../lei-records/null-utils'
+import { getRegistrationStatusBadgePresentation } from '../lei-records/null-utils'
 
 export interface LEIAuditEntry {
   id: string
@@ -321,14 +320,19 @@ function SnapshotValue({ fieldKey, value, snapshot, showCodes = true, countryByC
   }
   if (fieldKey === 'registration_status' && typeof value === 'string' && value.trim().length > 0) {
     const regStatusPresentation = getRegistrationStatusBadgePresentation(value)
+    const variantStyles = {
+      success: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+      destructive: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+      warning: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+      muted: 'theme-subtle',
+    }
     return (
-      <Badge
+      <span
         title={regStatusPresentation.tooltip}
-        className="inline-block whitespace-nowrap"
-        variant={REGISTRATION_STATUS_BADGE_VARIANT[regStatusPresentation.variant]}
+        className={`inline-block whitespace-nowrap px-2 py-1 text-xs rounded ${variantStyles[regStatusPresentation.variant]}`}
       >
         {regStatusPresentation.label}
-      </Badge>
+      </span>
     )
   }
   if (LEI_CODE_FIELDS.has(fieldKey) && typeof value === 'string' && value.trim().length > 0) {

--- a/frontend/app/lei-records/null-utils.test.ts
+++ b/frontend/app/lei-records/null-utils.test.ts
@@ -78,7 +78,7 @@ describe('getRegistrationStatusBadgePresentation', () => {
   it('returns green badge for ISSUED status', () => {
     const result = getRegistrationStatusBadgePresentation('ISSUED')
     expect(result).toEqual({
-      label: 'Issued',
+      label: 'ISSUED',
       tooltip: 'Registration is active and valid',
       variant: 'success',
     })
@@ -150,7 +150,7 @@ describe('getRegistrationStatusBadgePresentation', () => {
   it('handles lowercase input correctly', () => {
     const result = getRegistrationStatusBadgePresentation('issued')
     expect(result).toEqual({
-      label: 'Issued',
+      label: 'ISSUED',
       tooltip: 'Registration is active and valid',
       variant: 'success',
     })

--- a/frontend/app/lei-records/null-utils.ts
+++ b/frontend/app/lei-records/null-utils.ts
@@ -1,10 +1,3 @@
-export const REGISTRATION_STATUS_BADGE_VARIANT: Record<RegistrationStatusVariant, 'green' | 'red' | 'yellow' | 'gray'> = {
-  success: 'green',
-  destructive: 'red',
-  warning: 'yellow',
-  muted: 'gray',
-}
-
 import { formatDateOnlyDisplay, isPlaceholderDateValue } from '../lib/date-display'
 
 export function isNullLikeValue(value: unknown): value is string {
@@ -75,7 +68,7 @@ export function getRegistrationStatusBadgePresentation(value: unknown): {
 
   // Active status
   if (rawValue === 'ISSUED') {
-    return { label: formatEnumDisplayValue(rawValue), tooltip, variant: 'success' }
+    return { label: 'ISSUED', tooltip, variant: 'success' }
   }
 
   // Invalid/lapsed statuses

--- a/frontend/app/lei-records/page.tsx
+++ b/frontend/app/lei-records/page.tsx
@@ -3,7 +3,6 @@
 import { MouseEvent as ReactMouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import Alert from '../components/Alert'
-import Badge from '../components/Badge'
 import CountryFlag from '../components/CountryFlag'
 import LEIOtherNamesList from '../components/LEIOtherNamesList'
 import PageHeader from '../components/PageHeader'
@@ -25,14 +24,7 @@ import { useUserPreference } from '../lib/useUserPreference'
 import { useSearchFocusShortcut } from '../lib/useSearchFocusShortcut'
 import MapLink from '../components/MapLink'
 import { getRelativeTimeInfo, getRelativeTimeTranslationKey } from './date-utils'
-import {
-  formatEnumDisplayValue,
-  formatLEICellValue,
-  getStatusBadgePresentation,
-  getRegistrationStatusBadgePresentation,
-  normalizeRecordNullLikeValues,
-  REGISTRATION_STATUS_BADGE_VARIANT,
-} from './null-utils'
+import { formatEnumDisplayValue, formatLEICellValue, getStatusBadgePresentation, getRegistrationStatusBadgePresentation, normalizeRecordNullLikeValues } from './null-utils'
 import { formatStatusFilterLabel, LEI_STATUS_FILTER_OPTIONS, normalizeStatusFilterForAPI } from './status-filter'
 import { computeShowingEnd, formatCurrentPageStatValue } from './stats-format'
 import { useTranslation } from 'react-i18next'
@@ -1731,7 +1723,7 @@ export default function LEIRecordsPage() {
                         data-row-index={index}
                         onClick={() => handleRecordClick(record)}
                         onContextMenu={(e) => handleRowContextMenu(e, record)}
-                        className="group theme-table-row-hover transition-[background-color] cursor-pointer"
+                        className="group theme-table-row-hover transition-colors cursor-pointer"
                         style={{ height: 'auto', minHeight: '48px' }}
                       >
                         {visibleColumnsInOrder.map((column) => {
@@ -1936,14 +1928,19 @@ export default function LEIRecordsPage() {
                               ) : isRegistrationStatus ? (
                                 (() => {
                                   const regStatusPresentation = getRegistrationStatusBadgePresentation(value)
+                                  const variantStyles = {
+                                    success: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+                                    destructive: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+                                    warning: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+                                    muted: 'theme-subtle',
+                                  }
                                   return (
-                                    <Badge
+                                    <span
                                       title={regStatusPresentation.tooltip}
-                                      className="inline-block whitespace-nowrap"
-                                      variant={REGISTRATION_STATUS_BADGE_VARIANT[regStatusPresentation.variant]}
+                                      className={`inline-block whitespace-nowrap px-2 py-1 text-xs rounded ${variantStyles[regStatusPresentation.variant]}`}
                                     >
                                       {regStatusPresentation.label}
-                                    </Badge>
+                                    </span>
                                   )
                                 })()
                               ) : isNextRenewalDate ? (
@@ -2487,15 +2484,20 @@ export default function LEIRecordsPage() {
                     <span className="text-xs font-medium text-[rgb(var(--muted-foreground-rgb))] uppercase">{t('leiRecords.columns.labels.registrationStatus')}</span>
                     {(() => {
                       const regStatusPresentation = getRegistrationStatusBadgePresentation(selectedRecord.registration_status)
+                      const variantStyles = {
+                        success: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+                        destructive: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+                        warning: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+                        muted: 'theme-subtle',
+                      }
                       return (
                         <p className="mt-1">
-                                  <Badge
-                                    title={regStatusPresentation.tooltip}
-                                    className="inline-block whitespace-nowrap"
-                                    variant={REGISTRATION_STATUS_BADGE_VARIANT[regStatusPresentation.variant]}
-                                  >
+                          <span
+                            title={regStatusPresentation.tooltip}
+                            className={`inline-block whitespace-nowrap px-2 py-1 text-xs rounded ${variantStyles[regStatusPresentation.variant]}`}
+                          >
                             {regStatusPresentation.label}
-                                  </Badge>
+                          </span>
                         </p>
                       )
                     })()}


### PR DESCRIPTION
## Purpose
Restore main to the state before PR #356 was merged so unresolved testing issues can be addressed in a follow-up PR.

## What this does
- reverts commit `1f7c507` (PR #356 squash merge)
- removes the #356 LEI badge changes from main

## Follow-up
A new replacement PR will be opened immediately after this revert lands, carrying the #356 changes forward for further fixes and testing without auto-merging.