### PR TITLE
fix(ci): address unresolved #367 review threads before merge policy

### DIFF
--- a/.github/skills/github-issues/SKILL.md
+++ b/.github/skills/github-issues/SKILL.md
@@ -90,7 +90,8 @@ State values: `open`, `closed`
 - When work starts on a linked issue, replace `status: triage` with `status: in progress`
 - When the linked PR merges, replace `status: in progress` with `status: done`
 - If work stops and the linked PR closes without merge, move the issue back to `status: triage`
-- Preserve category labels such as `bug`, `enhancement`, `documentation`, `security`, and `performance`
+- Preserve category labels such as `bug`, `enhancement`, `security`, and `performance`
+- For documentation-focused work, use `area:docs` instead of adding a duplicate `documentation` label
 
 ## Examples
 
@@ -134,7 +135,6 @@ Use these standard labels when applicable:
 | --- | --- |
 | `bug` | Something isn't working |
 | `enhancement` | New feature or improvement |
-| `documentation` | Documentation updates |
 | `good first issue` | Good for newcomers |
 | `help wanted` | Extra attention needed |
 | `question` | Further information requested |

--- a/.github/workflows/check-pr-issue-link.yml
+++ b/.github/workflows/check-pr-issue-link.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -42,12 +43,13 @@ jobs:
             const body = pr.body || ''
 
             // Closing keywords: closes/fixes/resolves/refs/relates to + #N
-            const hasClosingKeyword = /\b(closes?|fixes?|resolves?|refs?|relates?\s+to)\s+#\d+/i.test(body)
+            // Also support GitHub-accepted `Fixes: #123` style.
+            const hasClosingKeyword = /\b(closes?|fixes?|resolves?|refs?|relates?\s+to)(?:\s+|:\s*)#\d+/i.test(body)
 
             // Guardrail: closing keywords must target ISSUES, never PULL REQUESTS.
             // (Refs/Relates do not auto-close and are not blocked.)
             const closingKeywordMatches = [
-              ...body.matchAll(/\b(closes?|fixes?|resolves?)\s+#(\d+)\b/gi),
+              ...body.matchAll(/\b(closes?|fixes?|resolves?)(?:\s+|:\s*)#(\d+)\b/gi),
             ]
             const closingTargets = [...new Set(closingKeywordMatches.map((m) => Number(m[2])))]
 
@@ -64,7 +66,12 @@ jobs:
                   closingTargetsThatArePRs.push(targetNumber)
                 }
               } catch (error) {
-                // If target cannot be fetched, ignore here and continue.
+                const details = error?.status ? `status ${error.status}` : String(error)
+                core.setFailed(
+                  `Unable to verify closing keyword target #${targetNumber} (${details}). ` +
+                    'Do not use Closes/Fixes/Resolves until target verification succeeds.'
+                )
+                return
               }
             }
 

--- a/.github/workflows/check-pr-issue-link.yml
+++ b/.github/workflows/check-pr-issue-link.yml
@@ -13,7 +13,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   check-issue-link:

--- a/.github/workflows/check-unresolved-review-threads.yml
+++ b/.github/workflows/check-unresolved-review-threads.yml
@@ -1,0 +1,86 @@
+name: Check Unresolved Review Threads
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - edited
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-unresolved-review-threads:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail when unresolved review threads remain
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number
+
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    reviewThreads(first: 100, after: $cursor) {
+                      pageInfo {
+                        hasNextPage
+                        endCursor
+                      }
+                      nodes {
+                        isResolved
+                        isOutdated
+                        path
+                      }
+                    }
+                  }
+                }
+              }
+            `
+
+            const unresolved = []
+            let cursor = null
+            let hasNextPage = true
+
+            while (hasNextPage) {
+              const result = await github.graphql(query, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: prNumber,
+                cursor,
+              })
+
+              const threads = result.repository.pullRequest.reviewThreads
+              for (const thread of threads.nodes) {
+                // Outdated threads are kept out of the hard-fail set; active unresolved threads block merges.
+                if (!thread.isResolved && !thread.isOutdated) {
+                  unresolved.push(thread.path || '(unknown file)')
+                }
+              }
+
+              hasNextPage = threads.pageInfo.hasNextPage
+              cursor = threads.pageInfo.endCursor
+            }
+
+            if (unresolved.length === 0) {
+              core.info('No active unresolved review threads found.')
+              return
+            }
+
+            const counts = unresolved.reduce((acc, path) => {
+              acc[path] = (acc[path] || 0) + 1
+              return acc
+            }, {})
+
+            const summary = Object.entries(counts)
+              .map(([path, count]) => `${path}: ${count}`)
+              .join(', ')
+
+            core.setFailed(
+              `PR has unresolved review conversations. Resolve all active threads before merge. (${summary})`
+            )

--- a/.github/workflows/check-unresolved-review-threads.yml
+++ b/.github/workflows/check-unresolved-review-threads.yml
@@ -1,16 +1,23 @@
 name: Check Unresolved Review Threads
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
       - edited
       - reopened
       - ready_for_review
+  pull_request_review_thread:
+    types:
+      - resolved
+      - unresolved
+  pull_request_review:
+    types:
+      - submitted
+      - dismissed
 
 permissions:
-  contents: read
   pull-requests: read
 
 jobs:

--- a/docker/Dockerfile.backend.clean
+++ b/docker/Dockerfile.backend.clean
@@ -16,10 +16,10 @@ WORKDIR /app
 # Install build dependencies and ca-certificates
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
-	ca-certificates \
-	git=2.47.3-r0 \
-	make=4.4.1-r2 \
-	&& update-ca-certificates
+    ca-certificates \
+    git=2.47.3-r0 \
+    make=4.4.1-r2 \
+    && update-ca-certificates
 
 # Copy go mod files
 COPY go.mod ./


### PR DESCRIPTION
## Summary
- Fix check-pr-issue-link guardrail gaps called out in unresolved #367 review threads.
- Add a hard CI gate that fails PRs with active unresolved review conversations.
- Normalize indentation in docker/Dockerfile.backend.clean continuation block.

## Thread-by-thread Remediation
1. **Colon-form closing keywords bypass**
   - Updated regex to detect Fixes: #123 / Closes: #123 forms.
2. **Missing issue API permissions**
   - Added issues: write permission to workflow.
3. **Silent catch weakens guardrail**
   - Catch now fails check with actionable message when target verification fails.
4. **Unresolved conversations merged**
   - Added new workflow: .github/workflows/check-unresolved-review-threads.yml.
   - Fails when active unresolved (non-outdated) review threads exist.
5. **Dockerfile indentation consistency**
   - Converted tabs to spaces in docker/Dockerfile.backend.clean multiline pk add block.

## Validation
- Get-Content docker/Dockerfile.backend.clean -Raw | docker run --rm -i hadolint/hadolint:v2.12.0
- make docs-check-fix
- make docs-check

## Linked Work
- Issue(s): Refs #363
- [x] No linked issue — reason: post-merge remediation for unresolved review conversations and merge gating
