### PR TITLE
fix: enforce review completion before merge or close

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -649,6 +649,17 @@ When an AI agent creates a pull request, it should complete standard PR hygiene 
    - PR link.
 6. Do not ask whether to post the summary/checklist/issue-update comments; post them by default.
 
+### Merge/Close Review Gate (REQUIRED)
+
+Before merging a PR, closing a linked PR, or announcing a PR as ready to merge, the agent must verify review completion:
+
+1. Confirm no unresolved review threads remain on the target PR.
+2. Confirm all required reviews are complete and no review is pending for the latest commit.
+3. Confirm no new Copilot/reviewer comments were added after the latest fix commit without a corresponding reply.
+4. If any of the above checks fail, do not merge or close; address feedback first and re-check.
+
+Use this gate even when checks are green. CI success alone is not sufficient for merge/close decisions.
+
 Only ask follow-up questions if required metadata cannot be applied (for example, reviewer handle is unavailable).
 
 ## GitHub Comment Formatting (REQUIRED)

--- a/.github/instructions/copilot-pr-feedback-resolution.instructions.md
+++ b/.github/instructions/copilot-pr-feedback-resolution.instructions.md
@@ -249,6 +249,10 @@ If you cannot locate a Copilot comment ID:
 
 - Post individual resolutions **immediately after pushing each fix**
 - Post comprehensive summary **after all fixes are pushed and CI has started**
+- Do not merge or close PRs until review completion is verified:
+  - all review threads resolved,
+  - no pending reviewer feedback for the latest commit,
+  - and no unaddressed Copilot comments remain.
 
 ### Clarity
 

--- a/.github/workflows/check-pr-issue-link.yml
+++ b/.github/workflows/check-pr-issue-link.yml
@@ -42,9 +42,9 @@ jobs:
 
             const body = pr.body || ''
 
-            // Closing keywords: closes/fixes/resolves/refs/relates to + #N
-            // Also support GitHub-accepted `Fixes: #123` style.
-            const hasClosingKeyword = /\b(closes?|fixes?|resolves?|refs?|relates?\s+to)(?:\s+|:\s*)#\d+/i.test(body)
+            // Issue-reference keywords: closes/fixes/resolves/refs/relates to + #N
+            // Also support GitHub-accepted colon forms such as `Fixes: #123`.
+            const hasIssueReferenceKeyword = /\b(closes?|fixes?|resolves?|refs?|relates?\s+to)(?:\s+|:\s*)#\d+/i.test(body)
 
             // Guardrail: closing keywords must target ISSUES, never PULL REQUESTS.
             // (Refs/Relates do not auto-close and are not blocked.)
@@ -110,7 +110,7 @@ jobs:
             // Template override checkbox checked
             const noIssueChecked = /- \[x\] no linked issue/i.test(body)
 
-            if (hasClosingKeyword || hasLinkedClosingIssue || noIssueChecked) {
+            if (hasIssueReferenceKeyword || hasLinkedClosingIssue || noIssueChecked) {
               core.info('Issue link or override found')
               return
             }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,7 +82,6 @@
     "println": true,
     "psql": true,
     "Push-Location": true,
-    "select": true,
     "Set-Content": true,
     "sqlfluff": true,
     "Start-Process": true,


### PR DESCRIPTION
## Summary
- Clarify issue-reference variable naming in the PR issue-link workflow (`hasIssueReferenceKeyword`) so it matches behavior (`Refs`/`Relates` + closing keywords).
- Remove broad terminal auto-approve `select` entry from workspace settings.
- Add an explicit merge/close review-completion gate to Copilot instructions.
- Add matching timing guidance in PR feedback-resolution instructions to require resolved threads and addressed comments before merge/close.

## Validation
- make docs-check-fix
- make docs-check