### PR TITLE
fix: allow authenticated admin access to code-mappings page

### DIFF
--- a/frontend/app/code-mappings/page.tsx
+++ b/frontend/app/code-mappings/page.tsx
@@ -9,6 +9,7 @@ import PageHeader from '../components/PageHeader'
 import SearchInputWithOverflowTooltip from '../components/SearchInputWithOverflowTooltip'
 import StatCard from '../components/StatCard'
 import { getApiBaseUrl } from '../lib/api-base'
+import { buildCodeMappingsHeaders } from './request'
 import { useEnglishTooltips } from '../lib/useEnglishTooltips'
 import { useSearchFocusShortcut } from '../lib/useSearchFocusShortcut'
 
@@ -43,9 +44,7 @@ export default function CodeMappingsPage() {
   const fetchMappings = useCallback(async () => {
     try {
       const response = await fetch(`${API_BASE_URL}/api/v1/code-mappings?limit=100`, {
-        headers: {
-          'Accept': 'application/json'
-        }
+        headers: buildCodeMappingsHeaders(),
       })
 
       if (response.ok) {

--- a/frontend/app/code-mappings/request.test.ts
+++ b/frontend/app/code-mappings/request.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { buildCodeMappingsHeaders } from './request'
+
+describe('buildCodeMappingsHeaders', () => {
+  it('includes Authorization header when token is present', () => {
+    const headers = buildCodeMappingsHeaders('jwt-token') as Record<string, string>
+
+    expect(headers.Accept).toBe('application/json')
+    expect(headers.Authorization).toBe('Bearer jwt-token')
+  })
+
+  it('only includes Accept header when token is absent', () => {
+    const headers = buildCodeMappingsHeaders(null) as Record<string, string>
+
+    expect(headers.Accept).toBe('application/json')
+    expect(headers.Authorization).toBeUndefined()
+  })
+})

--- a/frontend/app/code-mappings/request.ts
+++ b/frontend/app/code-mappings/request.ts
@@ -1,0 +1,16 @@
+import { getAuthToken } from '../lib/auth-token'
+
+export function buildCodeMappingsHeaders(token = getAuthToken()): HeadersInit {
+  const headers: HeadersInit = {
+    Accept: 'application/json',
+  }
+
+  if (token) {
+    return {
+      ...headers,
+      Authorization: `Bearer ${token}`,
+    }
+  }
+
+  return headers
+}


### PR DESCRIPTION
## Summary
Fixes #360 by including the bearer token on code-mappings fetch requests so authenticated admin users can access /code-mappings data.

## Changes
- Add `buildCodeMappingsHeaders()` helper for code-mappings requests
- Include `Authorization: Bearer <token>` when auth token is present
- Keep existing unauthenticated handling behavior
- Add regression tests for header construction

## Validation
- npm test -- app/code-mappings/request.test.ts
- npm run lint