### PR TITLE
feat: add section breadcrumbs for dashboard-launched pages

### DIFF
--- a/frontend/app/components/PageHeader.tsx
+++ b/frontend/app/components/PageHeader.tsx
@@ -2,11 +2,13 @@
 
 import React, { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { useTranslation } from 'react-i18next'
 import UserBadge from './UserBadge'
 import ContextDocsLink from './ContextDocsLink'
 import { useButtonEmojiMode } from '../lib/useButtonEmojiMode'
 import { resolveHydrationSafeLabel } from '../lib/hydrationSafeLabel'
+import { getDashboardPageSection } from '../lib/dashboard-sections'
 
 interface PageHeaderProps {
   title: string
@@ -34,8 +36,10 @@ export default function PageHeader({
   actions,
 }: PageHeaderProps) {
   const { t } = useTranslation('common')
+  const pathname = usePathname()
   const [hasHydrated, setHasHydrated] = useState(false)
   const { formatLabel } = useButtonEmojiMode()
+  const dashboardPageSection = getDashboardPageSection(pathname)
 
   useEffect(() => {
     setHasHydrated(true)
@@ -59,6 +63,34 @@ export default function PageHeader({
   return (
     <div className="mb-8 flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
       <div>
+        {dashboardPageSection && (
+          <nav
+            aria-label={t('leftNav.title')}
+            className="mb-3 overflow-x-auto"
+          >
+            <ol className="flex min-w-max items-center gap-2 text-xs sm:text-sm theme-text-muted">
+              <li>
+                <Link href="/dashboard" className="theme-link hover:opacity-80 rounded theme-focus">
+                  {t('leftNav.items.dashboard')}
+                </Link>
+              </li>
+              <li aria-hidden="true">›</li>
+              <li>
+                <Link
+                  href={dashboardPageSection.section.href}
+                  className="theme-link hover:opacity-80 rounded theme-focus"
+                >
+                  {t(dashboardPageSection.section.titleKey)}
+                </Link>
+              </li>
+              <li aria-hidden="true">›</li>
+              <li className="font-medium text-[rgb(var(--foreground-rgb))]" aria-current="page">
+                {t(dashboardPageSection.pageTitleKey)}
+              </li>
+            </ol>
+          </nav>
+        )}
+
         {showBackLink && (
           <Link
             href={backHref}

--- a/frontend/app/components/PageHeader.tsx
+++ b/frontend/app/components/PageHeader.tsx
@@ -65,7 +65,7 @@ export default function PageHeader({
       <div>
         {dashboardPageSection && (
           <nav
-            aria-label={t('leftNav.title')}
+            aria-label={t('nav.breadcrumbs', 'Breadcrumbs')}
             className="mb-3 overflow-x-auto"
           >
             <ol className="flex min-w-max items-center gap-2 text-xs sm:text-sm theme-text-muted">

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useTranslation } from 'react-i18next'
 import LEIStatusCard from '../components/LEIStatusCard'
 import LEIRecordsCard from '../components/LEIRecordsCard'
@@ -15,13 +15,21 @@ import AdminSection from '../components/AdminSection'
 import { getAuthToken } from '../lib/auth-token'
 import { useEnglishTooltips } from '../lib/useEnglishTooltips'
 import { buildDocsUrl } from '../lib/docsLinks'
+import { getDashboardSectionById } from '../lib/dashboard-sections'
 
 export default function DashboardPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { t } = useTranslation('common')
   const { getEnglishTooltip } = useEnglishTooltips()
   const [mounted, setMounted] = useState(false)
   const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const activeSection = getDashboardSectionById(searchParams.get('section'))
+
+  const showPublicReferenceData = !activeSection || activeSection.id === 'public-reference-data'
+  const showMasterData = !activeSection || activeSection.id === 'master-data-management'
+  const showDataAcquisition = !activeSection || activeSection.id === 'data-acquisition-processing'
+  const showAdministration = !activeSection || activeSection.id === 'administration'
 
   useEffect(() => {
     setMounted(true)
@@ -93,9 +101,27 @@ export default function DashboardPage() {
 
         <section className="mb-8">
           <h2 className="text-3xl font-bold mb-2" title={getEnglishTooltip('dashboard.moduleCatalog.title')}>{t('dashboard.moduleCatalog.title')}</h2>
-          <p className="theme-text-muted" title={getEnglishTooltip('dashboard.moduleCatalog.subtitle')}>{t('dashboard.moduleCatalog.subtitle')}</p>
+          {!activeSection && (
+            <p className="theme-text-muted" title={getEnglishTooltip('dashboard.moduleCatalog.subtitle')}>
+              {t('dashboard.moduleCatalog.subtitle')}
+            </p>
+          )}
+          {activeSection && (
+            <div className="mt-3 flex flex-wrap items-center gap-3">
+              <p className="theme-text-muted">
+                {t(activeSection.titleKey)}
+              </p>
+              <Link
+                href="/dashboard"
+                className="inline-flex items-center rounded-md theme-btn-neutral px-3 py-1.5 text-xs font-medium"
+              >
+                {t('nav.backToDashboard')}
+              </Link>
+            </div>
+          )}
         </section>
 
+        {showPublicReferenceData && (
         <section className="mb-12">
           <div className="flex items-center mb-6">
             <span className="text-2xl mr-3">🌍</span>
@@ -111,7 +137,9 @@ export default function DashboardPage() {
             <LEIRecordsCard />
           </div>
         </section>
+        )}
 
+        {showMasterData && (
         <section className="mb-12">
           <div className="flex items-center mb-6">
             <span className="text-2xl mr-3">📊</span>
@@ -158,7 +186,9 @@ export default function DashboardPage() {
             />
           </div>
         </section>
+        )}
 
+        {showDataAcquisition && (
         <section className="mb-12">
           <div className="flex items-center mb-6">
             <span className="text-2xl mr-3">📡</span>
@@ -188,8 +218,9 @@ export default function DashboardPage() {
             </div>
           </div>
         </section>
+        )}
 
-        <AdminSection />
+        {showAdministration && <AdminSection />}
       </div>
     </main>
   )

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import Image from 'next/image'
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useTranslation } from 'react-i18next'
 import LEIStatusCard from '../components/LEIStatusCard'
@@ -18,6 +18,26 @@ import { buildDocsUrl } from '../lib/docsLinks'
 import { getDashboardSectionById } from '../lib/dashboard-sections'
 
 export default function DashboardPage() {
+  return (
+    <Suspense fallback={<DashboardPageFallback />}>
+      <DashboardPageContent />
+    </Suspense>
+  )
+}
+
+function DashboardPageFallback() {
+  const { t } = useTranslation('common')
+
+  return (
+    <main className="min-h-screen p-8">
+      <div className="max-w-7xl mx-auto text-sm theme-text-muted">
+        {t('dashboard.redirecting')}
+      </div>
+    </main>
+  )
+}
+
+function DashboardPageContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const { t } = useTranslation('common')

--- a/frontend/app/lib/dashboard-sections.test.ts
+++ b/frontend/app/lib/dashboard-sections.test.ts
@@ -12,6 +12,18 @@ describe('getDashboardSectionById', () => {
   it('returns null for unknown section ids', () => {
     expect(getDashboardSectionById('unknown')).toBeNull()
   })
+
+  it('normalizes leading/trailing whitespace in the id', () => {
+    const section = getDashboardSectionById('  master-data-management  ')
+
+    expect(section?.id).toBe('master-data-management')
+  })
+
+  it('normalizes mixed-case ids', () => {
+    const section = getDashboardSectionById('Master-Data-Management')
+
+    expect(section?.id).toBe('master-data-management')
+  })
 })
 
 describe('getDashboardPageSection', () => {

--- a/frontend/app/lib/dashboard-sections.test.ts
+++ b/frontend/app/lib/dashboard-sections.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { getDashboardPageSection, getDashboardSectionById } from './dashboard-sections'
+
+describe('getDashboardSectionById', () => {
+  it('returns section metadata for a known section id', () => {
+    const section = getDashboardSectionById('master-data-management')
+
+    expect(section?.titleKey).toBe('leftNav.sections.masterData')
+    expect(section?.href).toBe('/dashboard?section=master-data-management')
+  })
+
+  it('returns null for unknown section ids', () => {
+    expect(getDashboardSectionById('unknown')).toBeNull()
+  })
+})
+
+describe('getDashboardPageSection', () => {
+  it('maps dashboard page routes to section and page title keys', () => {
+    const page = getDashboardPageSection('/code-mappings')
+
+    expect(page?.section.id).toBe('master-data-management')
+    expect(page?.pageTitleKey).toBe('leftNav.items.codeMappings')
+  })
+
+  it('returns null for routes that are not part of dashboard sections', () => {
+    expect(getDashboardPageSection('/login')).toBeNull()
+  })
+})

--- a/frontend/app/lib/dashboard-sections.ts
+++ b/frontend/app/lib/dashboard-sections.ts
@@ -1,0 +1,81 @@
+export type DashboardSectionId =
+  | 'public-reference-data'
+  | 'master-data-management'
+  | 'data-acquisition-processing'
+  | 'administration'
+
+export interface DashboardSectionMeta {
+  id: DashboardSectionId
+  titleKey: string
+  href: string
+}
+
+export interface DashboardPageSectionMeta {
+  section: DashboardSectionMeta
+  pageTitleKey: string
+}
+
+const DASHBOARD_SECTIONS: Record<DashboardSectionId, DashboardSectionMeta> = {
+  'public-reference-data': {
+    id: 'public-reference-data',
+    titleKey: 'leftNav.sections.publicData',
+    href: '/dashboard?section=public-reference-data',
+  },
+  'master-data-management': {
+    id: 'master-data-management',
+    titleKey: 'leftNav.sections.masterData',
+    href: '/dashboard?section=master-data-management',
+  },
+  'data-acquisition-processing': {
+    id: 'data-acquisition-processing',
+    titleKey: 'leftNav.sections.dataAcquisition',
+    href: '/dashboard?section=data-acquisition-processing',
+  },
+  administration: {
+    id: 'administration',
+    titleKey: 'leftNav.sections.admin',
+    href: '/dashboard?section=administration',
+  },
+}
+
+const DASHBOARD_PAGE_SECTION_MAP: Record<string, { sectionId: DashboardSectionId; pageTitleKey: string }> = {
+  '/countries': { sectionId: 'public-reference-data', pageTitleKey: 'leftNav.items.countries' },
+  '/currencies': { sectionId: 'public-reference-data', pageTitleKey: 'leftNav.items.currencies' },
+  '/languages': { sectionId: 'public-reference-data', pageTitleKey: 'leftNav.items.languages' },
+  '/lei-records': { sectionId: 'public-reference-data', pageTitleKey: 'leftNav.items.leiRecords' },
+
+  '/instruments': { sectionId: 'master-data-management', pageTitleKey: 'leftNav.items.instruments' },
+  '/accounts': { sectionId: 'master-data-management', pageTitleKey: 'leftNav.items.accounts' },
+  '/ssi': { sectionId: 'master-data-management', pageTitleKey: 'leftNav.items.ssi' },
+  '/code-mappings': { sectionId: 'master-data-management', pageTitleKey: 'leftNav.items.codeMappings' },
+
+  '/lei': { sectionId: 'data-acquisition-processing', pageTitleKey: 'leftNav.items.syncTriggers' },
+
+  '/admin/users': { sectionId: 'administration', pageTitleKey: 'leftNav.items.adminUsers' },
+  '/admin/translations': { sectionId: 'administration', pageTitleKey: 'leftNav.items.adminTranslations' },
+}
+
+export function getDashboardSectionById(id: string | null | undefined): DashboardSectionMeta | null {
+  if (!id) {
+    return null
+  }
+
+  const normalized = id.trim().toLowerCase() as DashboardSectionId
+  return DASHBOARD_SECTIONS[normalized] ?? null
+}
+
+export function getDashboardPageSection(pathname: string | null | undefined): DashboardPageSectionMeta | null {
+  if (!pathname) {
+    return null
+  }
+
+  const route = DASHBOARD_PAGE_SECTION_MAP[pathname]
+  if (!route) {
+    return null
+  }
+
+  return {
+    section: DASHBOARD_SECTIONS[route.sectionId],
+    pageTitleKey: route.pageTitleKey,
+  }
+}

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -32,6 +32,7 @@
     }
   },
   "nav": {
+    "breadcrumbs": "Breadcrumbs",
     "backToHome": "← Back to Home",
     "backToDashboard": "← Back to Dashboard",
     "backToLogin": "← Back to Login",


### PR DESCRIPTION
## Summary
Fixes #345 by adding section-aware breadcrumbs on dashboard-launched pages and a section-level dashboard options view.

## Changes
- Added route-to-section mapping in `app/lib/dashboard-sections.ts`
- Added automated tests for section mapping logic
- Updated `PageHeader` to render: `Dashboard > Section > Current Page`
- Made dashboard support section-level views via `?section=` query values
- Section breadcrumb now links to the corresponding section-level dashboard options view

## Validation
- `npm test -- app/lib/dashboard-sections.test.ts`
- `npm run lint`
- `npm run i18n:verify`

## Notes
- Breadcrumb labels are i18n-backed using existing translation keys.
- Current page breadcrumb item is rendered as non-clickable text.