### PR TITLE
Refresh LEI count cache when Level 1 load completes

### DIFF
--- a/backend/internal/service/lei_service.go
+++ b/backend/internal/service/lei_service.go
@@ -136,6 +136,9 @@ type leiService struct {
 	dataDir     string // Directory to store downloaded files
 
 	lookupCacheMu              sync.RWMutex
+	leiCount                   int64
+	leiCountCached             bool
+	leiCountCachedAt           time.Time
 	distinctCategories         []string
 	distinctCategoriesCachedAt time.Time
 	distinctRegions            []string
@@ -160,6 +163,15 @@ func cloneStringSlice(values []string) []string {
 	cloned := make([]string, len(values))
 	copy(cloned, values)
 	return cloned
+}
+
+func isLevel1CountMutatingJob(jobType string) bool {
+	switch strings.ToUpper(strings.TrimSpace(jobType)) {
+	case "LEVEL1_FULL", "LEVEL1_DELTA":
+		return true
+	default:
+		return false
+	}
 }
 
 func statusJobTypeFromFileType(fileType string) string {
@@ -599,6 +611,7 @@ func (s *leiService) ProcessSourceFileWithResume(sourceFileID uuid.UUID, resumeF
 	if err := s.repo.UpdateSourceFile(sourceFile); err != nil {
 		return fmt.Errorf("failed to update source file status: %w", err)
 	}
+	s.refreshLEICountCacheForJob(sourceFile.JobType)
 
 	log.Info().
 		Str("source_file_id", sourceFileID.String()).
@@ -608,6 +621,30 @@ func (s *leiService) ProcessSourceFileWithResume(sourceFileID uuid.UUID, resumeF
 		Msg("File processing completed")
 
 	return nil
+}
+
+func (s *leiService) refreshLEICountCache() error {
+	count, err := s.repo.CountLEIRecords()
+	if err != nil {
+		return err
+	}
+
+	s.lookupCacheMu.Lock()
+	s.leiCount = count
+	s.leiCountCached = true
+	s.lookupCacheMu.Unlock()
+
+	return nil
+}
+
+func (s *leiService) refreshLEICountCacheForJob(jobType string) {
+	if !isLevel1CountMutatingJob(jobType) {
+		return
+	}
+
+	if err := s.refreshLEICountCache(); err != nil {
+		log.Warn().Err(err).Str("job_type", jobType).Msg("Failed to refresh cached LEI count after Level 1 processing")
+	}
 }
 
 // extractZipFile extracts the JSON file from a ZIP archive
@@ -1565,7 +1602,23 @@ func (s *leiService) GetAllLEIWithFilters(limit, offset int, search, status, cat
 
 // CountLEIRecords returns the total count of LEI records
 func (s *leiService) CountLEIRecords() (int64, error) {
-	return s.repo.CountLEIRecords()
+	s.lookupCacheMu.RLock()
+	if s.leiCountCached {
+		cachedCount := s.leiCount
+		s.lookupCacheMu.RUnlock()
+		return cachedCount, nil
+	}
+	s.lookupCacheMu.RUnlock()
+
+	if err := s.refreshLEICountCache(); err != nil {
+		return 0, err
+	}
+
+	s.lookupCacheMu.RLock()
+	cachedCount := s.leiCount
+	s.lookupCacheMu.RUnlock()
+
+	return cachedCount, nil
 }
 
 // GetLegalNamesByLEICodes returns a map of LEI code → legal name for a batch of codes.

--- a/backend/internal/service/lei_service.go
+++ b/backend/internal/service/lei_service.go
@@ -138,7 +138,6 @@ type leiService struct {
 	lookupCacheMu              sync.RWMutex
 	leiCount                   int64
 	leiCountCached             bool
-	leiCountCachedAt           time.Time
 	distinctCategories         []string
 	distinctCategoriesCachedAt time.Time
 	distinctRegions            []string

--- a/backend/internal/service/lei_service_test.go
+++ b/backend/internal/service/lei_service_test.go
@@ -783,3 +783,102 @@ func TestProcessRecordsArray_FinalUpdatePersistsLastProcessedLEIForSmallFiles(t 
 		t.Fatalf("expected LastProcessedLEI %q, got %q", wantLastLEI, *finalSnapshot.LastProcessedLEI)
 	}
 }
+
+type leiCountRepoStub struct {
+	repository.LEIRepository
+	counts    []int64
+	callCount int
+}
+
+func (s *leiCountRepoStub) CountLEIRecords() (int64, error) {
+	s.callCount++
+	if len(s.counts) == 0 {
+		return 0, nil
+	}
+
+	idx := s.callCount - 1
+	if idx >= len(s.counts) {
+		idx = len(s.counts) - 1
+	}
+
+	return s.counts[idx], nil
+}
+
+func TestCountLEIRecords_UsesCachedValueUntilExplicitRefresh(t *testing.T) {
+	repoStub := &leiCountRepoStub{counts: []int64{123, 999}}
+	svc := &leiService{repo: repoStub}
+
+	first, err := svc.CountLEIRecords()
+	if err != nil {
+		t.Fatalf("first CountLEIRecords returned error: %v", err)
+	}
+
+	second, err := svc.CountLEIRecords()
+	if err != nil {
+		t.Fatalf("second CountLEIRecords returned error: %v", err)
+	}
+
+	if first != 123 {
+		t.Fatalf("expected first count to be 123, got %d", first)
+	}
+	if second != 123 {
+		t.Fatalf("expected second count to use cached value 123, got %d", second)
+	}
+	if repoStub.callCount != 1 {
+		t.Fatalf("expected repository count to be called once, got %d", repoStub.callCount)
+	}
+}
+
+func TestRefreshLEICountCacheForJob_Level1JobUpdatesCachedValue(t *testing.T) {
+	repoStub := &leiCountRepoStub{counts: []int64{123, 456}}
+	svc := &leiService{repo: repoStub}
+
+	first, err := svc.CountLEIRecords()
+	if err != nil {
+		t.Fatalf("first CountLEIRecords returned error: %v", err)
+	}
+
+	svc.refreshLEICountCacheForJob("LEVEL1_FULL")
+
+	second, err := svc.CountLEIRecords()
+	if err != nil {
+		t.Fatalf("second CountLEIRecords returned error: %v", err)
+	}
+
+	if first != 123 {
+		t.Fatalf("expected first count to be 123, got %d", first)
+	}
+	if second != 456 {
+		t.Fatalf("expected refreshed count to be 456 after Level 1 refresh, got %d", second)
+	}
+	if repoStub.callCount != 2 {
+		t.Fatalf("expected repository count to be called twice, got %d", repoStub.callCount)
+	}
+}
+
+func TestRefreshLEICountCacheForJob_NonLevel1JobDoesNotUpdateCachedValue(t *testing.T) {
+	repoStub := &leiCountRepoStub{counts: []int64{123, 456}}
+	svc := &leiService{repo: repoStub}
+
+	first, err := svc.CountLEIRecords()
+	if err != nil {
+		t.Fatalf("first CountLEIRecords returned error: %v", err)
+	}
+
+	svc.refreshLEICountCacheForJob("LEVEL2_RR")
+
+	second, err := svc.CountLEIRecords()
+	if err != nil {
+		t.Fatalf("second CountLEIRecords returned error: %v", err)
+	}
+
+	if first != 123 {
+		t.Fatalf("expected first count to be 123, got %d", first)
+	}
+	if second != 123 {
+		t.Fatalf("expected cached count to remain 123 for non-Level 1 jobs, got %d", second)
+	}
+	if repoStub.callCount != 1 {
+		t.Fatalf("expected repository count to be called once, got %d", repoStub.callCount)
+	}
+}


### PR DESCRIPTION
## Summary
Refresh the cached `/api/v1/lei/count` value when a Level 1 LEI load completes instead of expiring it on a timer.

## Why
The LEI count only changes when the Level 1 loader writes new data. Polling the count endpoint throughout the day was repeatedly forcing an expensive `COUNT(*)` query even when the table could not have changed.

## Changes
- cache the LEI count in the service after the first read
- refresh that cache only after successful `LEVEL1_FULL` and `LEVEL1_DELTA` processing
- add unit tests for cached reads, Level 1 refresh, and non-Level 1 no-op behavior

## Validation
- `cd backend && go test ./internal/service`

## Notes
- This PR intentionally contains only the backend count-cache change.
- No linked issue.