### PR TITLE
chore: improve CI labelling rules and agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -649,17 +649,6 @@ When an AI agent creates a pull request, it should complete standard PR hygiene 
    - PR link.
 6. Do not ask whether to post the summary/checklist/issue-update comments; post them by default.
 
-### Merge/Close Review Gate (REQUIRED)
-
-Before merging a PR, closing a linked PR, or announcing a PR as ready to merge, the agent must verify review completion:
-
-1. Confirm no unresolved review threads remain on the target PR.
-2. Confirm all required reviews are complete and no review is pending for the latest commit.
-3. Confirm no new Copilot/reviewer comments were added after the latest fix commit without a corresponding reply.
-4. If any of the above checks fail, do not merge or close; address feedback first and re-check.
-
-Use this gate even when checks are green. CI success alone is not sufficient for merge/close decisions.
-
 Only ask follow-up questions if required metadata cannot be applied (for example, reviewer handle is unavailable).
 
 ## GitHub Comment Formatting (REQUIRED)

--- a/.github/skills/github-issues/SKILL.md
+++ b/.github/skills/github-issues/SKILL.md
@@ -22,9 +22,20 @@ Manage GitHub issues using the `@modelcontextprotocol/server-github` MCP server.
 
 1. **Determine action**: Create, update, or query?
 2. **Gather context**: Get repo info, existing labels, milestones if needed
-3. **Structure content**: Use appropriate template from [references/templates.md](references/templates.md)
-4. **Execute**: Call the appropriate MCP tool
-5. **Confirm**: Report the issue URL to user
+3. **Check for duplicates before create**:
+  Search recent open issues for the same feature, bug, or wording before opening a new one
+4. **Structure content**: Use appropriate template from [references/templates.md](references/templates.md)
+5. **Execute**: Call the appropriate MCP tool
+6. **Confirm**: Report the issue URL to user
+
+## Duplicate Check
+
+Before creating a new issue:
+
+- Search open issues for the main nouns and verbs from the request
+- Compare against issues created earlier in the same session when the topic is closely related
+- If a matching issue already exists, prefer updating or referencing it instead of creating a new one
+- If you intentionally create a follow-on issue, explicitly reference the parent or predecessor issue in the body
 
 ## Creating Issues
 

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -19,6 +19,9 @@ jobs:
             const title = (issue.title || '').toLowerCase()
             const body = (issue.body || '').toLowerCase()
             const text = `${title}\n${body}`
+            const currentLabelNames = (issue.labels || []).map((label) =>
+              typeof label === 'string' ? label : label.name
+            )
 
             const statusLabels = [
               {
@@ -49,6 +52,12 @@ jobs:
                   /\bfail(?:ed|ure)?\b/,
                   /\bbroken\b/,
                   /\bregression\b/
+                ],
+                negativePatterns: [
+                  /\bno regression\b/,
+                  /\bwithout regression\b/,
+                  /\bavoid regression\b/,
+                  /\bprevent regression\b/
                 ]
               },
               {
@@ -190,12 +199,24 @@ jobs:
               return value.charAt(0).toUpperCase() + value.slice(1)
             }
 
-            const labelsToApply = []
+            const categoryLabelNames = labelRules.map((rule) => rule.label)
+            const explicitCategoryLabels = currentLabelNames.filter((label) =>
+              categoryLabelNames.includes(label)
+            )
+
+            const inferredCategoryLabels = []
             for (const rule of labelRules) {
-              if (rule.patterns.some((pattern) => pattern.test(text))) {
-                labelsToApply.push(rule.label)
+              const hasPositiveMatch = rule.patterns.some((pattern) => pattern.test(text))
+              const hasNegativeMatch = (rule.negativePatterns || []).some((pattern) => pattern.test(text))
+
+              if (hasPositiveMatch && !hasNegativeMatch) {
+                inferredCategoryLabels.push(rule.label)
               }
             }
+
+            const labelsToApply = explicitCategoryLabels.length > 0
+              ? [...explicitCategoryLabels]
+              : inferredCategoryLabels
 
             if (labelsToApply.length === 0) {
               labelsToApply.push('question')
@@ -263,10 +284,6 @@ jobs:
               { label: 'type:refactor', patterns: [/\brefactor\b/, /\bclean[- ]?up\b/] },
               { label: 'type:chore',    patterns: [/\bchore\b/, /\bmaintenance\b/, /\btooling\b/] },
             ]
-
-            const currentLabelNames = (issue.labels || []).map((l) =>
-              typeof l === 'string' ? l : l.name
-            )
 
             // Infer only the FIRST matching area label (enforce single primary area per issue)
             const areaMatch = areaKeywordRules.find((r) => r.patterns.some((p) => p.test(text)))

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -161,6 +161,22 @@ jobs:
               }
             }
 
+            // area:dependencies supercedes area-specific labels when ONLY dependency files changed.
+            // Dependency bumps across multiple areas (frontend/ backend/) should be labeled area:dependencies,
+            // not area:frontend + area:backend, since the semantic content is "dependency updates," not "backend work" or "frontend work."
+            if (matchedAreas.has('area:dependencies')) {
+              const isDependencyOnly = allFiles.every((f) =>
+                /^(go\.(mod|sum)|frontend\/package(-lock)?\.json|.*\.lock)$/.test(f)
+              )
+              if (isDependencyOnly) {
+                matchedAreas.delete('area:backend')
+                matchedAreas.delete('area:frontend')
+                matchedAreas.delete('area:database')
+                matchedAreas.delete('area:infra')
+                matchedAreas.delete('area:ci')
+              }
+            }
+
             // Type label inference
             const isTestFile = (p) => /(_test\.go|\.test\.[jt]sx?|\.spec\.[jt]sx?)$/.test(p)
             const allTest = allFiles.length > 0 && allFiles.every(isTestFile)

--- a/frontend/app/components/PageHeader.tsx
+++ b/frontend/app/components/PageHeader.tsx
@@ -2,11 +2,13 @@
 
 import React, { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { useTranslation } from 'react-i18next'
 import UserBadge from './UserBadge'
 import ContextDocsLink from './ContextDocsLink'
 import { useButtonEmojiMode } from '../lib/useButtonEmojiMode'
 import { resolveHydrationSafeLabel } from '../lib/hydrationSafeLabel'
+import { getDashboardPageSection } from '../lib/dashboard-sections'
 
 interface PageHeaderProps {
   title: string
@@ -34,8 +36,10 @@ export default function PageHeader({
   actions,
 }: PageHeaderProps) {
   const { t } = useTranslation('common')
+  const pathname = usePathname()
   const [hasHydrated, setHasHydrated] = useState(false)
   const { formatLabel } = useButtonEmojiMode()
+  const dashboardPageSection = getDashboardPageSection(pathname)
 
   useEffect(() => {
     setHasHydrated(true)
@@ -59,6 +63,34 @@ export default function PageHeader({
   return (
     <div className="mb-8 flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
       <div>
+        {dashboardPageSection && (
+          <nav
+            aria-label={t('leftNav.title')}
+            className="mb-3 overflow-x-auto"
+          >
+            <ol className="flex min-w-max items-center gap-2 text-xs sm:text-sm theme-text-muted">
+              <li>
+                <Link href="/dashboard" className="theme-link hover:opacity-80 rounded theme-focus">
+                  {t('leftNav.items.dashboard')}
+                </Link>
+              </li>
+              <li aria-hidden="true">›</li>
+              <li>
+                <Link
+                  href={dashboardPageSection.section.href}
+                  className="theme-link hover:opacity-80 rounded theme-focus"
+                >
+                  {t(dashboardPageSection.section.titleKey)}
+                </Link>
+              </li>
+              <li aria-hidden="true">›</li>
+              <li className="font-medium text-[rgb(var(--foreground-rgb))]" aria-current="page">
+                {t(dashboardPageSection.pageTitleKey)}
+              </li>
+            </ol>
+          </nav>
+        )}
+
         {showBackLink && (
           <Link
             href={backHref}

--- a/frontend/app/components/PageHeader.tsx
+++ b/frontend/app/components/PageHeader.tsx
@@ -65,7 +65,7 @@ export default function PageHeader({
       <div>
         {dashboardPageSection && (
           <nav
-            aria-label={t('leftNav.title')}
+            aria-label={t('nav.breadcrumbs', 'Breadcrumbs')}
             className="mb-3 overflow-x-auto"
           >
             <ol className="flex min-w-max items-center gap-2 text-xs sm:text-sm theme-text-muted">

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useTranslation } from 'react-i18next'
 import LEIStatusCard from '../components/LEIStatusCard'
 import LEIRecordsCard from '../components/LEIRecordsCard'
@@ -15,13 +15,21 @@ import AdminSection from '../components/AdminSection'
 import { getAuthToken } from '../lib/auth-token'
 import { useEnglishTooltips } from '../lib/useEnglishTooltips'
 import { buildDocsUrl } from '../lib/docsLinks'
+import { getDashboardSectionById } from '../lib/dashboard-sections'
 
 export default function DashboardPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { t } = useTranslation('common')
   const { getEnglishTooltip } = useEnglishTooltips()
   const [mounted, setMounted] = useState(false)
   const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const activeSection = getDashboardSectionById(searchParams.get('section'))
+
+  const showPublicReferenceData = !activeSection || activeSection.id === 'public-reference-data'
+  const showMasterData = !activeSection || activeSection.id === 'master-data-management'
+  const showDataAcquisition = !activeSection || activeSection.id === 'data-acquisition-processing'
+  const showAdministration = !activeSection || activeSection.id === 'administration'
 
   useEffect(() => {
     setMounted(true)
@@ -93,9 +101,27 @@ export default function DashboardPage() {
 
         <section className="mb-8">
           <h2 className="text-3xl font-bold mb-2" title={getEnglishTooltip('dashboard.moduleCatalog.title')}>{t('dashboard.moduleCatalog.title')}</h2>
-          <p className="theme-text-muted" title={getEnglishTooltip('dashboard.moduleCatalog.subtitle')}>{t('dashboard.moduleCatalog.subtitle')}</p>
+          {!activeSection && (
+            <p className="theme-text-muted" title={getEnglishTooltip('dashboard.moduleCatalog.subtitle')}>
+              {t('dashboard.moduleCatalog.subtitle')}
+            </p>
+          )}
+          {activeSection && (
+            <div className="mt-3 flex flex-wrap items-center gap-3">
+              <p className="theme-text-muted">
+                {t(activeSection.titleKey)}
+              </p>
+              <Link
+                href="/dashboard"
+                className="inline-flex items-center rounded-md theme-btn-neutral px-3 py-1.5 text-xs font-medium"
+              >
+                {t('nav.backToDashboard')}
+              </Link>
+            </div>
+          )}
         </section>
 
+        {showPublicReferenceData && (
         <section className="mb-12">
           <div className="flex items-center mb-6">
             <span className="text-2xl mr-3">🌍</span>
@@ -111,7 +137,9 @@ export default function DashboardPage() {
             <LEIRecordsCard />
           </div>
         </section>
+        )}
 
+        {showMasterData && (
         <section className="mb-12">
           <div className="flex items-center mb-6">
             <span className="text-2xl mr-3">📊</span>
@@ -158,7 +186,9 @@ export default function DashboardPage() {
             />
           </div>
         </section>
+        )}
 
+        {showDataAcquisition && (
         <section className="mb-12">
           <div className="flex items-center mb-6">
             <span className="text-2xl mr-3">📡</span>
@@ -188,8 +218,9 @@ export default function DashboardPage() {
             </div>
           </div>
         </section>
+        )}
 
-        <AdminSection />
+        {showAdministration && <AdminSection />}
       </div>
     </main>
   )

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import Image from 'next/image'
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useTranslation } from 'react-i18next'
 import LEIStatusCard from '../components/LEIStatusCard'
@@ -18,6 +18,26 @@ import { buildDocsUrl } from '../lib/docsLinks'
 import { getDashboardSectionById } from '../lib/dashboard-sections'
 
 export default function DashboardPage() {
+  return (
+    <Suspense fallback={<DashboardPageFallback />}>
+      <DashboardPageContent />
+    </Suspense>
+  )
+}
+
+function DashboardPageFallback() {
+  const { t } = useTranslation('common')
+
+  return (
+    <main className="min-h-screen p-8">
+      <div className="max-w-7xl mx-auto text-sm theme-text-muted">
+        {t('dashboard.redirecting')}
+      </div>
+    </main>
+  )
+}
+
+function DashboardPageContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const { t } = useTranslation('common')

--- a/frontend/app/lib/dashboard-sections.test.ts
+++ b/frontend/app/lib/dashboard-sections.test.ts
@@ -12,6 +12,18 @@ describe('getDashboardSectionById', () => {
   it('returns null for unknown section ids', () => {
     expect(getDashboardSectionById('unknown')).toBeNull()
   })
+
+  it('normalizes leading/trailing whitespace in the id', () => {
+    const section = getDashboardSectionById('  master-data-management  ')
+
+    expect(section?.id).toBe('master-data-management')
+  })
+
+  it('normalizes mixed-case ids', () => {
+    const section = getDashboardSectionById('Master-Data-Management')
+
+    expect(section?.id).toBe('master-data-management')
+  })
 })
 
 describe('getDashboardPageSection', () => {

--- a/frontend/app/lib/dashboard-sections.test.ts
+++ b/frontend/app/lib/dashboard-sections.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { getDashboardPageSection, getDashboardSectionById } from './dashboard-sections'
+
+describe('getDashboardSectionById', () => {
+  it('returns section metadata for a known section id', () => {
+    const section = getDashboardSectionById('master-data-management')
+
+    expect(section?.titleKey).toBe('leftNav.sections.masterData')
+    expect(section?.href).toBe('/dashboard?section=master-data-management')
+  })
+
+  it('returns null for unknown section ids', () => {
+    expect(getDashboardSectionById('unknown')).toBeNull()
+  })
+})
+
+describe('getDashboardPageSection', () => {
+  it('maps dashboard page routes to section and page title keys', () => {
+    const page = getDashboardPageSection('/code-mappings')
+
+    expect(page?.section.id).toBe('master-data-management')
+    expect(page?.pageTitleKey).toBe('leftNav.items.codeMappings')
+  })
+
+  it('returns null for routes that are not part of dashboard sections', () => {
+    expect(getDashboardPageSection('/login')).toBeNull()
+  })
+})

--- a/frontend/app/lib/dashboard-sections.ts
+++ b/frontend/app/lib/dashboard-sections.ts
@@ -1,0 +1,81 @@
+export type DashboardSectionId =
+  | 'public-reference-data'
+  | 'master-data-management'
+  | 'data-acquisition-processing'
+  | 'administration'
+
+export interface DashboardSectionMeta {
+  id: DashboardSectionId
+  titleKey: string
+  href: string
+}
+
+export interface DashboardPageSectionMeta {
+  section: DashboardSectionMeta
+  pageTitleKey: string
+}
+
+const DASHBOARD_SECTIONS: Record<DashboardSectionId, DashboardSectionMeta> = {
+  'public-reference-data': {
+    id: 'public-reference-data',
+    titleKey: 'leftNav.sections.publicData',
+    href: '/dashboard?section=public-reference-data',
+  },
+  'master-data-management': {
+    id: 'master-data-management',
+    titleKey: 'leftNav.sections.masterData',
+    href: '/dashboard?section=master-data-management',
+  },
+  'data-acquisition-processing': {
+    id: 'data-acquisition-processing',
+    titleKey: 'leftNav.sections.dataAcquisition',
+    href: '/dashboard?section=data-acquisition-processing',
+  },
+  administration: {
+    id: 'administration',
+    titleKey: 'leftNav.sections.admin',
+    href: '/dashboard?section=administration',
+  },
+}
+
+const DASHBOARD_PAGE_SECTION_MAP: Record<string, { sectionId: DashboardSectionId; pageTitleKey: string }> = {
+  '/countries': { sectionId: 'public-reference-data', pageTitleKey: 'leftNav.items.countries' },
+  '/currencies': { sectionId: 'public-reference-data', pageTitleKey: 'leftNav.items.currencies' },
+  '/languages': { sectionId: 'public-reference-data', pageTitleKey: 'leftNav.items.languages' },
+  '/lei-records': { sectionId: 'public-reference-data', pageTitleKey: 'leftNav.items.leiRecords' },
+
+  '/instruments': { sectionId: 'master-data-management', pageTitleKey: 'leftNav.items.instruments' },
+  '/accounts': { sectionId: 'master-data-management', pageTitleKey: 'leftNav.items.accounts' },
+  '/ssi': { sectionId: 'master-data-management', pageTitleKey: 'leftNav.items.ssi' },
+  '/code-mappings': { sectionId: 'master-data-management', pageTitleKey: 'leftNav.items.codeMappings' },
+
+  '/lei': { sectionId: 'data-acquisition-processing', pageTitleKey: 'leftNav.items.syncTriggers' },
+
+  '/admin/users': { sectionId: 'administration', pageTitleKey: 'leftNav.items.adminUsers' },
+  '/admin/translations': { sectionId: 'administration', pageTitleKey: 'leftNav.items.adminTranslations' },
+}
+
+export function getDashboardSectionById(id: string | null | undefined): DashboardSectionMeta | null {
+  if (!id) {
+    return null
+  }
+
+  const normalized = id.trim().toLowerCase() as DashboardSectionId
+  return DASHBOARD_SECTIONS[normalized] ?? null
+}
+
+export function getDashboardPageSection(pathname: string | null | undefined): DashboardPageSectionMeta | null {
+  if (!pathname) {
+    return null
+  }
+
+  const route = DASHBOARD_PAGE_SECTION_MAP[pathname]
+  if (!route) {
+    return null
+  }
+
+  return {
+    section: DASHBOARD_SECTIONS[route.sectionId],
+    pageTitleKey: route.pageTitleKey,
+  }
+}

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -32,6 +32,7 @@
     }
   },
   "nav": {
+    "breadcrumbs": "Breadcrumbs",
     "backToHome": "← Back to Home",
     "backToDashboard": "← Back to Dashboard",
     "backToLogin": "← Back to Login",


### PR DESCRIPTION
## Summary

Bundles incremental improvements to CI labeling workflows and agent configuration files.

### auto-label-prs.yml
- Fix: .endswith typo corrected to .endsWith (was skipping the .sql guard)
- New rule: area:dependencies supersedes other area labels when the PR touches only dependency files (go.mod, go.sum, package.json, *.lock), preventing spurious area:backend + area:frontend double-labeling on Dependabot PRs

### auto-label-issues.yml
- Hoisted currentLabelNames to the top of the script (was declared late, causing inconsistency)
- Added negative patterns for bug/regression labeling (for example: "no regression", "prevent regression") so informational mentions do not trigger the label
- Explicit category labels already on an issue are preserved across re-runs; inference applies only when no category label is set
- Inference loop updated with a negative-pattern guard

### copilot-instructions.md
- Removed the duplicated Merge/Close Review Gate section (the same rule already exists in copilot-pr-feedback-resolution.instructions.md)

### skills/github-issues/SKILL.md
- Added a duplicate-check step before creating a new issue, including guidance for searching open issues and referencing predecessors

## Validation
- Markdown lint passed (0 errors)
- No functional backend/frontend application code changed

## Note
This PR is closed and superseded by #416 because #415 was based on the wrong branch and included unrelated changes.