### PR TITLE
chore: improve CI labelling rules and agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -649,17 +649,6 @@ When an AI agent creates a pull request, it should complete standard PR hygiene 
    - PR link.
 6. Do not ask whether to post the summary/checklist/issue-update comments; post them by default.
 
-### Merge/Close Review Gate (REQUIRED)
-
-Before merging a PR, closing a linked PR, or announcing a PR as ready to merge, the agent must verify review completion:
-
-1. Confirm no unresolved review threads remain on the target PR.
-2. Confirm all required reviews are complete and no review is pending for the latest commit.
-3. Confirm no new Copilot/reviewer comments were added after the latest fix commit without a corresponding reply.
-4. If any of the above checks fail, do not merge or close; address feedback first and re-check.
-
-Use this gate even when checks are green. CI success alone is not sufficient for merge/close decisions.
-
 Only ask follow-up questions if required metadata cannot be applied (for example, reviewer handle is unavailable).
 
 ## GitHub Comment Formatting (REQUIRED)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -649,6 +649,17 @@ When an AI agent creates a pull request, it should complete standard PR hygiene 
    - PR link.
 6. Do not ask whether to post the summary/checklist/issue-update comments; post them by default.
 
+### Merge/Close Review Gate (REQUIRED)
+
+Before merging a PR, closing a linked PR, or announcing readiness to merge:
+
+1. Confirm no unresolved review threads remain.
+2. Confirm required reviews are complete and nothing is pending for the latest commit.
+3. Confirm no new reviewer/Copilot comments were added after the latest fix without a reply.
+
+This is a high-visibility reminder; execution details are defined in
+[`instructions/copilot-pr-feedback-resolution.instructions.md`](instructions/copilot-pr-feedback-resolution.instructions.md).
+
 Only ask follow-up questions if required metadata cannot be applied (for example, reviewer handle is unavailable).
 
 ## GitHub Comment Formatting (REQUIRED)

--- a/.github/skills/github-issues/SKILL.md
+++ b/.github/skills/github-issues/SKILL.md
@@ -22,9 +22,20 @@ Manage GitHub issues using the `@modelcontextprotocol/server-github` MCP server.
 
 1. **Determine action**: Create, update, or query?
 2. **Gather context**: Get repo info, existing labels, milestones if needed
-3. **Structure content**: Use appropriate template from [references/templates.md](references/templates.md)
-4. **Execute**: Call the appropriate MCP tool
-5. **Confirm**: Report the issue URL to user
+3. **Check for duplicates before create**:
+  Search recent open issues for the same feature, bug, or wording before opening a new one
+4. **Structure content**: Use appropriate template from [references/templates.md](references/templates.md)
+5. **Execute**: Call the appropriate MCP tool
+6. **Confirm**: Report the issue URL to user
+
+## Duplicate Check
+
+Before creating a new issue:
+
+- Search open issues for the main nouns and verbs from the request
+- Compare against issues created earlier in the same session when the topic is closely related
+- If a matching issue already exists, prefer updating or referencing it instead of creating a new one
+- If you intentionally create a follow-on issue, explicitly reference the parent or predecessor issue in the body
 
 ## Creating Issues
 

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -19,6 +19,9 @@ jobs:
             const title = (issue.title || '').toLowerCase()
             const body = (issue.body || '').toLowerCase()
             const text = `${title}\n${body}`
+            const currentLabelNames = (issue.labels || []).map((label) =>
+              typeof label === 'string' ? label : label.name
+            )
 
             const statusLabels = [
               {
@@ -49,6 +52,12 @@ jobs:
                   /\bfail(?:ed|ure)?\b/,
                   /\bbroken\b/,
                   /\bregression\b/
+                ],
+                negativePatterns: [
+                  /\bno regression\b/,
+                  /\bwithout regression\b/,
+                  /\bavoid regression\b/,
+                  /\bprevent regression\b/
                 ]
               },
               {
@@ -190,12 +199,24 @@ jobs:
               return value.charAt(0).toUpperCase() + value.slice(1)
             }
 
-            const labelsToApply = []
+            const categoryLabelNames = labelRules.map((rule) => rule.label)
+            const explicitCategoryLabels = currentLabelNames.filter((label) =>
+              categoryLabelNames.includes(label)
+            )
+
+            const inferredCategoryLabels = []
             for (const rule of labelRules) {
-              if (rule.patterns.some((pattern) => pattern.test(text))) {
-                labelsToApply.push(rule.label)
+              const hasPositiveMatch = rule.patterns.some((pattern) => pattern.test(text))
+              const hasNegativeMatch = (rule.negativePatterns || []).some((pattern) => pattern.test(text))
+
+              if (hasPositiveMatch && !hasNegativeMatch) {
+                inferredCategoryLabels.push(rule.label)
               }
             }
+
+            const labelsToApply = explicitCategoryLabels.length > 0
+              ? [...explicitCategoryLabels]
+              : inferredCategoryLabels
 
             if (labelsToApply.length === 0) {
               labelsToApply.push('question')
@@ -263,10 +284,6 @@ jobs:
               { label: 'type:refactor', patterns: [/\brefactor\b/, /\bclean[- ]?up\b/] },
               { label: 'type:chore',    patterns: [/\bchore\b/, /\bmaintenance\b/, /\btooling\b/] },
             ]
-
-            const currentLabelNames = (issue.labels || []).map((l) =>
-              typeof l === 'string' ? l : l.name
-            )
 
             // Infer only the FIRST matching area label (enforce single primary area per issue)
             const areaMatch = areaKeywordRules.find((r) => r.patterns.some((p) => p.test(text)))

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -206,8 +206,23 @@ jobs:
 
             const inferredCategoryLabels = []
             for (const rule of labelRules) {
-              const hasPositiveMatch = rule.patterns.some((pattern) => pattern.test(text))
-              const hasNegativeMatch = (rule.negativePatterns || []).some((pattern) => pattern.test(text))
+              let hasPositiveMatch = rule.patterns.some((pattern) => pattern.test(text))
+              let hasNegativeMatch = (rule.negativePatterns || []).some((pattern) => pattern.test(text))
+
+              if (rule.label === 'bug') {
+                const hasDirectBugSignal = [
+                  /\bbug\b/,
+                  /\berror\b/,
+                  /\bfail(?:ed|ure)?\b/,
+                  /\bbroken\b/
+                ].some((pattern) => pattern.test(text))
+                const hasRegressionSignal = /\bregression\b/.test(text)
+                const suppressRegressionSignal = (rule.negativePatterns || []).some((pattern) => pattern.test(text))
+
+                // Keep bug inference from direct bug words, and only suppress the regression-specific signal.
+                hasPositiveMatch = hasDirectBugSignal || (hasRegressionSignal && !suppressRegressionSignal)
+                hasNegativeMatch = false
+              }
 
               if (hasPositiveMatch && !hasNegativeMatch) {
                 inferredCategoryLabels.push(rule.label)

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -161,6 +161,22 @@ jobs:
               }
             }
 
+            // area:dependencies supercedes area-specific labels when ONLY dependency files changed.
+            // Dependency bumps across multiple areas (frontend/ backend/) should be labeled area:dependencies,
+            // not area:frontend + area:backend, since the semantic content is "dependency updates," not "backend work" or "frontend work."
+            if (matchedAreas.has('area:dependencies')) {
+              const isDependencyOnly = allFiles.every((f) =>
+                /^(go\.(mod|sum)|frontend\/package(-lock)?\.json|.*\.lock)$/.test(f)
+              )
+              if (isDependencyOnly) {
+                matchedAreas.delete('area:backend')
+                matchedAreas.delete('area:frontend')
+                matchedAreas.delete('area:database')
+                matchedAreas.delete('area:infra')
+                matchedAreas.delete('area:ci')
+              }
+            }
+
             // Type label inference
             const isTestFile = (p) => /(_test\.go|\.test\.[jt]sx?|\.spec\.[jt]sx?)$/.test(p)
             const allTest = allFiles.length > 0 && allFiles.every(isTestFile)

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -161,12 +161,12 @@ jobs:
               }
             }
 
-            // area:dependencies supercedes area-specific labels when ONLY dependency files changed.
+            // area:dependencies supersedes area-specific labels when ONLY dependency files changed.
             // Dependency bumps across multiple areas (frontend/ backend/) should be labeled area:dependencies,
             // not area:frontend + area:backend, since the semantic content is "dependency updates," not "backend work" or "frontend work."
             if (matchedAreas.has('area:dependencies')) {
               const isDependencyOnly = allFiles.every((f) =>
-                /^(go\.(mod|sum)|frontend\/package(-lock)?\.json|.*\.lock)$/.test(f)
+                /^(?:(?:.*\/)?go\.(mod|sum)|(?:.*\/)?package(-lock)?\.json|.*\.lock)$/.test(f)
               )
               if (isDependencyOnly) {
                 matchedAreas.delete('area:backend')


### PR DESCRIPTION
## Summary

Bundles incremental improvements to CI labeling workflows and agent configuration files.

### auto-label-prs.yml
- Fix: .endswith typo corrected to .endsWith (was skipping the .sql guard)
- New rule: area:dependencies supersedes other area labels when the PR touches only dependency files (go.mod, go.sum, package.json, *.lock), preventing spurious area:backend + area:frontend double-labeling on Dependabot PRs

### auto-label-issues.yml
- Hoisted currentLabelNames to the top of the script (was declared late, causing inconsistency)
- Added negative patterns for bug/regression labeling (for example: "no regression", "prevent regression") so informational mentions do not trigger the label
- Explicit category labels already on an issue are preserved across re-runs; inference applies only when no category label is set
- Inference loop updated with a negative-pattern guard

### copilot-instructions.md
- Restored a concise Merge/Close Review Gate reminder and kept detailed execution in copilot-pr-feedback-resolution.instructions.md

### skills/github-issues/SKILL.md
- Added a duplicate-check step before creating a new issue, including guidance for searching open issues and referencing predecessors

## Validation
- Markdown lint passed (0 errors)
- No functional backend/frontend application code changed