### PR TITLE
fix(ci): tighten issue auto-labeling heuristics and deprecate documentation label

### DIFF
--- a/.github/tests/auto-label-issues.area-classification.test.mjs
+++ b/.github/tests/auto-label-issues.area-classification.test.mjs
@@ -1,0 +1,48 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+const areaKeywordRules = [
+  {
+    label: 'area:lei',
+    patterns: [/\blei\b/, /\bgleif\b/, /\blevel[- ]?2\b/, /\brelationship record\b/, /\breporting exception\b/]
+  },
+  { label: 'area:ci', patterns: [/\bgithub actions\b/, /\bworkflow\b/, /\bci\/cd\b/] },
+  {
+    label: 'area:database',
+    patterns: [
+      /\b(?:db|database|sql|schema|postgres(?:ql)?)\s+migrations?\b/,
+      /\bmigrations?\s+table\b/,
+      /\bpostgres\b/,
+      /\bschema\b/
+    ]
+  },
+  { label: 'area:infra', patterns: [/\bdocker\b/, /\bcontainer\b/, /\bcompose\b/, /\bnginx\b/] },
+  { label: 'area:frontend', patterns: [/\breact\b/, /\bnext\.?js\b/, /\btailwind\b/, /\bi18n\b/] },
+  { label: 'area:backend', patterns: [/\bgolang\b/, /\bgo service\b/, /\bgorm\b/] },
+  { label: 'area:dependencies', patterns: [/\bdependabot\b/, /\bdependency\b/, /\bgo\.mod\b/, /\bpackage\.json\b/] },
+  { label: 'area:docs', patterns: [/\badr\b/, /\barchitecture decision\b/] }
+]
+
+function inferArea(title, body) {
+  const text = `${(title || '').toLowerCase()}\n${(body || '').toLowerCase()}`
+  const match = areaKeywordRules.find((rule) => rule.patterns.some((pattern) => pattern.test(text)))
+  return match ? match.label : ''
+}
+
+test('classifies GitHub Actions migration guidance issue as CI, not database', () => {
+  const area = inferArea(
+    'Remove non-standard FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 runtime variable usage',
+    "Use GitHub's official migration guidance for JavaScript actions runtime deprecations in workflow files."
+  )
+
+  assert.equal(area, 'area:ci')
+})
+
+test('still classifies schema migration issues as database', () => {
+  const area = inferArea(
+    'Add database migration for retry tracking',
+    'Create PostgreSQL schema migration and apply migration table updates.'
+  )
+
+  assert.equal(area, 'area:database')
+})

--- a/.github/tests/auto-label-issues.documentation-classification.test.mjs
+++ b/.github/tests/auto-label-issues.documentation-classification.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+function allowPrefixOverride(existingTypedPrefix, hasExplicitTypedPrefix, needsRewrite, desiredPrefix, labelsToApply) {
+  const typedPrefixCategoryMap = {
+    bug: 'bug',
+    feature: 'enhancement',
+    security: 'security',
+    performance: 'performance',
+    question: 'question'
+  }
+  const existingTypedCategory = typedPrefixCategoryMap[existingTypedPrefix] || ''
+  const hasStaleDocsPrefix = existingTypedPrefix === 'docs' && Boolean(desiredPrefix)
+  const hasStaleTypedCategoryPrefix =
+    hasStaleDocsPrefix || (Boolean(existingTypedCategory) && !labelsToApply.includes(existingTypedCategory) && Boolean(desiredPrefix))
+
+  return !hasExplicitTypedPrefix || needsRewrite || hasStaleTypedCategoryPrefix
+}
+
+test('allows overriding stale docs prefix when non-doc category is inferred', () => {
+  const canOverride = allowPrefixOverride('docs', true, false, '[Feature]', ['enhancement'])
+  assert.equal(canOverride, true)
+})
+
+test('does not force override for matching typed prefix category', () => {
+  const canOverride = allowPrefixOverride('security', true, false, '[Security]', ['security'])
+  assert.equal(canOverride, false)
+})

--- a/.github/tests/auto-label-issues.documentation-classification.test.mjs
+++ b/.github/tests/auto-label-issues.documentation-classification.test.mjs
@@ -11,8 +11,11 @@ function allowPrefixOverride(existingTypedPrefix, hasExplicitTypedPrefix, needsR
   }
   const existingTypedCategory = typedPrefixCategoryMap[existingTypedPrefix] || ''
   const hasStaleDocsPrefix = existingTypedPrefix === 'docs' && Boolean(desiredPrefix)
+  const hasStaleTaskPrefix = existingTypedPrefix === 'task' && Boolean(desiredPrefix)
   const hasStaleTypedCategoryPrefix =
-    hasStaleDocsPrefix || (Boolean(existingTypedCategory) && !labelsToApply.includes(existingTypedCategory) && Boolean(desiredPrefix))
+    hasStaleDocsPrefix ||
+    hasStaleTaskPrefix ||
+    (Boolean(existingTypedCategory) && !labelsToApply.includes(existingTypedCategory) && Boolean(desiredPrefix))
 
   return !hasExplicitTypedPrefix || needsRewrite || hasStaleTypedCategoryPrefix
 }
@@ -25,4 +28,9 @@ test('allows overriding stale docs prefix when non-doc category is inferred', ()
 test('does not force override for matching typed prefix category', () => {
   const canOverride = allowPrefixOverride('security', true, false, '[Security]', ['security'])
   assert.equal(canOverride, false)
+})
+
+test('allows overriding stale task prefix when strong category is inferred', () => {
+  const canOverride = allowPrefixOverride('task', true, false, '[Bug]', ['bug'])
+  assert.equal(canOverride, true)
 })

--- a/.github/tests/auto-label-issues.primary-category.test.mjs
+++ b/.github/tests/auto-label-issues.primary-category.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+const categoryPriority = ['bug', 'security', 'performance', 'enhancement', 'documentation', 'question']
+
+function getPrimaryCategory(categories) {
+  return [...categories]
+    .sort((a, b) => {
+      const aRank = categoryPriority.indexOf(a)
+      const bRank = categoryPriority.indexOf(b)
+      return (aRank === -1 ? Number.MAX_SAFE_INTEGER : aRank) - (bRank === -1 ? Number.MAX_SAFE_INTEGER : bRank)
+    })
+    .at(0)
+}
+
+test('prefers security over documentation when both categories are present', () => {
+  const primary = getPrimaryCategory(['documentation', 'security'])
+  assert.equal(primary, 'security')
+})
+
+test('prefers bug over all other categories', () => {
+  const primary = getPrimaryCategory(['enhancement', 'question', 'bug'])
+  assert.equal(primary, 'bug')
+})

--- a/.github/tests/auto-label-issues.primary-category.test.mjs
+++ b/.github/tests/auto-label-issues.primary-category.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-const categoryPriority = ['bug', 'security', 'performance', 'enhancement', 'documentation', 'question']
+const categoryPriority = ['bug', 'security', 'performance', 'enhancement', 'question']
 
 function getPrimaryCategory(categories) {
   return [...categories]
@@ -13,8 +13,8 @@ function getPrimaryCategory(categories) {
     .at(0)
 }
 
-test('prefers security over documentation when both categories are present', () => {
-  const primary = getPrimaryCategory(['documentation', 'security'])
+test('prefers security over enhancement when both categories are present', () => {
+  const primary = getPrimaryCategory(['enhancement', 'security'])
   assert.equal(primary, 'security')
 })
 

--- a/.github/tests/auto-label-issues.question-classification.test.mjs
+++ b/.github/tests/auto-label-issues.question-classification.test.mjs
@@ -12,10 +12,6 @@ const labelRules = [
     patterns: [/\bfeature\b/, /\benhancement\b/, /\bimprovement\b/, /\bproposal\b/, /\brequest\b/]
   },
   {
-    label: 'documentation',
-    patterns: [/\bdoc(?:s|umentation)?\b/, /\breadme\b/, /\bguide\b/]
-  },
-  {
     label: 'security',
     patterns: [/\bsecurity\b/, /\bvulnerab(?:ility|le)\b/, /\bcve\b/, /\bauth(?:entication|orization)?\b/]
   },
@@ -41,7 +37,8 @@ const actionIntentPatterns = [
   /\bremove\b/,
   /\bimprove\b/,
   /\bintroduce\b/,
-  /\bsupport\b/
+  /\badd support\b/,
+  /\bsupport for\b/
 ]
 
 function inferCategoryLabels({ title, body }) {
@@ -95,6 +92,15 @@ test('does infer question for explicit question-mark title', () => {
   const labels = inferCategoryLabels({
     title: 'How should we handle stale LEI records?',
     body: 'Need guidance on whether to archive or soft-delete.'
+  })
+
+  assert.equal(labels.includes('question'), true)
+})
+
+test('does infer question when support is used as a question verb', () => {
+  const labels = inferCategoryLabels({
+    title: 'Does the system support SSO?',
+    body: 'Need to understand if this is already available.'
   })
 
   assert.equal(labels.includes('question'), true)

--- a/.github/tests/auto-label-issues.question-classification.test.mjs
+++ b/.github/tests/auto-label-issues.question-classification.test.mjs
@@ -1,0 +1,110 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+const labelRules = [
+  {
+    label: 'bug',
+    patterns: [/\bbug\b/, /\berror\b/, /\bfail(?:ed|ure)?\b/, /\bbroken\b/, /\bregression\b/],
+    negativePatterns: [/\bno regression\b/, /\bwithout regression\b/, /\bavoid regression\b/, /\bprevent regression\b/]
+  },
+  {
+    label: 'enhancement',
+    patterns: [/\bfeature\b/, /\benhancement\b/, /\bimprovement\b/, /\bproposal\b/, /\brequest\b/]
+  },
+  {
+    label: 'documentation',
+    patterns: [/\bdoc(?:s|umentation)?\b/, /\breadme\b/, /\bguide\b/]
+  },
+  {
+    label: 'security',
+    patterns: [/\bsecurity\b/, /\bvulnerab(?:ility|le)\b/, /\bcve\b/, /\bauth(?:entication|orization)?\b/]
+  },
+  {
+    label: 'performance',
+    patterns: [/\bperformance\b/, /\bslow\b/, /\blatency\b/, /\bthroughput\b/, /\bmemory\b/]
+  },
+  {
+    label: 'question',
+    patterns: [/\bquestion\b/, /\?/]
+  }
+]
+
+const actionIntentPatterns = [
+  /\badd\b/,
+  /\bimplement\b/,
+  /\bcreate\b/,
+  /\benable\b/,
+  /\ballow\b/,
+  /\bupdate\b/,
+  /\brefactor\b/,
+  /\bmigrate\b/,
+  /\bremove\b/,
+  /\bimprove\b/,
+  /\bintroduce\b/,
+  /\bsupport\b/
+]
+
+function inferCategoryLabels({ title, body }) {
+  const issue = { title, body }
+  const text = `${(title || '').toLowerCase()}\n${(body || '').toLowerCase()}`
+  const inferred = []
+
+  for (const rule of labelRules) {
+    let hasPositiveMatch = rule.patterns.some((pattern) => pattern.test(text))
+    let hasNegativeMatch = (rule.negativePatterns || []).some((pattern) => pattern.test(text))
+
+    if (rule.label === 'bug') {
+      const hasDirectBugSignal = [/\bbug\b/, /\berror\b/, /\bfail(?:ed|ure)?\b/, /\bbroken\b/].some((pattern) =>
+        pattern.test(text)
+      )
+      const hasRegressionSignal = /\bregression\b/.test(text)
+      const suppressRegressionSignal = (rule.negativePatterns || []).some((pattern) => pattern.test(text))
+
+      hasPositiveMatch = hasDirectBugSignal || (hasRegressionSignal && !suppressRegressionSignal)
+      hasNegativeMatch = false
+    }
+
+    if (rule.label === 'question') {
+      const hasQuestionMark = /\?/.test(issue.title || '') || /\n##\s*question\b/i.test(issue.body || '')
+      const hasQuestionKeyword = /\bquestion\b/.test(text)
+      const hasActionIntent = actionIntentPatterns.some((pattern) => pattern.test(text))
+
+      hasPositiveMatch = (hasQuestionMark || hasQuestionKeyword) && !hasActionIntent
+      hasNegativeMatch = false
+    }
+
+    if (hasPositiveMatch && !hasNegativeMatch) {
+      inferred.push(rule.label)
+    }
+  }
+
+  return inferred
+}
+
+test('does not infer question for action-oriented feature request text', () => {
+  const labels = inferCategoryLabels({
+    title: 'Add per-column filtering to the code-mappings table',
+    body:
+      'Users need per-column filtering to narrow results by source system, code type, or status.\n\nAcceptance criteria:\n- Add a filter for each column.'
+  })
+
+  assert.equal(labels.includes('question'), false)
+})
+
+test('does infer question for explicit question-mark title', () => {
+  const labels = inferCategoryLabels({
+    title: 'How should we handle stale LEI records?',
+    body: 'Need guidance on whether to archive or soft-delete.'
+  })
+
+  assert.equal(labels.includes('question'), true)
+})
+
+test('does not infer question when help text is action-oriented', () => {
+  const labels = inferCategoryLabels({
+    title: 'Add context help tooltip to code mappings filters',
+    body: 'Implement helper tooltip content for first-time users.'
+  })
+
+  assert.equal(labels.includes('question'), false)
+})

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -73,16 +73,6 @@ jobs:
                 ]
               },
               {
-                label: 'documentation',
-                color: '0075ca',
-                description: 'Documentation related',
-                patterns: [
-                  /\bdoc(?:s|umentation)?\b/,
-                  /\breadme\b/,
-                  /\bguide\b/
-                ]
-              },
-              {
                 label: 'security',
                 color: 'b60205',
                 description: 'Security related',
@@ -111,17 +101,29 @@ jobs:
                 description: 'Further information is requested',
                 patterns: [
                   /\bquestion\b/,
-                  /\bhow\b/,
-                  /\bwhy\b/,
-                  /\bhelp\b/
+                  /\?/
                 ]
               }
+            ]
+
+            const actionIntentPatterns = [
+              /\badd\b/,
+              /\bimplement\b/,
+              /\bcreate\b/,
+              /\benable\b/,
+              /\ballow\b/,
+              /\bupdate\b/,
+              /\brefactor\b/,
+              /\bmigrate\b/,
+              /\bremove\b/,
+              /\bimprove\b/,
+              /\bintroduce\b/,
+              /\bsupport\b/
             ]
 
             const titlePrefixes = {
               bug: '[Bug]',
               enhancement: '[Feature]',
-              documentation: '[Docs]',
               security: '[Security]',
               performance: '[Performance]',
               question: '[Question]'
@@ -203,6 +205,7 @@ jobs:
             const explicitCategoryLabels = currentLabelNames.filter((label) =>
               categoryLabelNames.includes(label)
             )
+            const categoryPriority = ['bug', 'security', 'performance', 'enhancement', 'question']
 
             const inferredCategoryLabels = []
             for (const rule of labelRules) {
@@ -224,6 +227,16 @@ jobs:
                 hasNegativeMatch = false
               }
 
+              if (rule.label === 'question') {
+                const hasQuestionMark = /\?/.test(issue.title || '') || /\n##\s*question\b/i.test(issue.body || '')
+                const hasQuestionKeyword = /\bquestion\b/.test(text)
+                const hasActionIntent = actionIntentPatterns.some((pattern) => pattern.test(text))
+
+                // Avoid classifying feature/task requests as questions unless they explicitly look like Q&A.
+                hasPositiveMatch = (hasQuestionMark || hasQuestionKeyword) && !hasActionIntent
+                hasNegativeMatch = false
+              }
+
               if (hasPositiveMatch && !hasNegativeMatch) {
                 inferredCategoryLabels.push(rule.label)
               }
@@ -233,16 +246,31 @@ jobs:
               ? [...explicitCategoryLabels]
               : inferredCategoryLabels
 
-            if (labelsToApply.length === 0) {
-              labelsToApply.push('question')
-            }
+            labelsToApply.sort((a, b) => {
+              const aRank = categoryPriority.indexOf(a)
+              const bRank = categoryPriority.indexOf(b)
+              return (aRank === -1 ? Number.MAX_SAFE_INTEGER : aRank) - (bRank === -1 ? Number.MAX_SAFE_INTEGER : bRank)
+            })
 
             const primaryLabel = labelsToApply[0]
             const currentTitle = (issue.title || '').trim()
             const existingPrefixMatch = currentTitle.match(/^\[[^\]]+\]\s*/)
             const existingPrefix = existingPrefixMatch ? existingPrefixMatch[0].trim() : ''
-            const desiredPrefix = titlePrefixes[primaryLabel] || '[Task]'
-            const hasExplicitTypedPrefix = /^\[(bug|feature|task|docs|security|performance|question)\]\s+/i.test(currentTitle)
+            const desiredPrefix = primaryLabel ? (titlePrefixes[primaryLabel] || '[Task]') : ''
+            const effectivePrefix = desiredPrefix || existingPrefix
+            const explicitTypedPrefixMatch = currentTitle.match(/^\[(bug|feature|task|docs|security|performance|question)\]\s+/i)
+            const hasExplicitTypedPrefix = Boolean(explicitTypedPrefixMatch)
+            const existingTypedPrefix = explicitTypedPrefixMatch ? explicitTypedPrefixMatch[1].toLowerCase() : ''
+            const typedPrefixCategoryMap = {
+              bug: 'bug',
+              feature: 'enhancement',
+              security: 'security',
+              performance: 'performance',
+              question: 'question'
+            }
+            const existingTypedCategory = typedPrefixCategoryMap[existingTypedPrefix] || ''
+            const hasStaleDocsPrefix = existingTypedPrefix === 'docs' && Boolean(desiredPrefix)
+            const hasStaleTypedCategoryPrefix = hasStaleDocsPrefix || (Boolean(existingTypedCategory) && !labelsToApply.includes(existingTypedCategory) && Boolean(desiredPrefix))
             const bodyCandidate = extractCandidateTitleFromBody(issue.body || '')
             const rawStrippedTitle = currentTitle.replace(/^\[[^\]]+\]\s*/, '').trim()
             const baseTitle = isWeakTitle(currentTitle)
@@ -251,10 +279,11 @@ jobs:
             const normalizedBaseTitle = toSentenceCase(baseTitle)
             const needsRewrite = isWeakTitle(currentTitle)
             const needsPrefix = !existingPrefix && normalizedBaseTitle.length > 0
-            const allowPrefixOverride = !hasExplicitTypedPrefix || needsRewrite
+            const allowPrefixOverride = !hasExplicitTypedPrefix || needsRewrite || hasStaleTypedCategoryPrefix
+            const shouldAdjustPrefix = desiredPrefix && existingPrefix !== desiredPrefix && allowPrefixOverride
 
-            if ((needsRewrite || (needsPrefix && allowPrefixOverride) || (existingPrefix !== desiredPrefix && allowPrefixOverride)) && normalizedBaseTitle) {
-              const nextTitle = `${desiredPrefix} ${normalizedBaseTitle}`.trim()
+            if ((needsRewrite || (needsPrefix && allowPrefixOverride) || shouldAdjustPrefix) && normalizedBaseTitle) {
+              const nextTitle = `${effectivePrefix} ${normalizedBaseTitle}`.trim()
               if (nextTitle !== issue.title) {
                 await github.rest.issues.update({
                   owner: context.repo.owner,
@@ -285,9 +314,9 @@ jobs:
 
             const areaKeywordRules = [
               { label: 'area:lei',          patterns: [/\blei\b/, /\bgleif\b/, /\blevel[- ]?2\b/, /\brelationship record\b/, /\breporting exception\b/] },
-              { label: 'area:database',     patterns: [/\bmigration\b/, /\bpostgres\b/, /\bschema\b/] },
-              { label: 'area:infra',        patterns: [/\bdocker\b/, /\bcontainer\b/, /\bcompose\b/, /\bnginx\b/] },
               { label: 'area:ci',           patterns: [/\bgithub actions\b/, /\bworkflow\b/, /\bci\/cd\b/] },
+              { label: 'area:database',     patterns: [/\b(?:db|database|sql|schema|postgres(?:ql)?)\s+migrations?\b/, /\bmigrations?\s+table\b/, /\bpostgres\b/, /\bschema\b/] },
+              { label: 'area:infra',        patterns: [/\bdocker\b/, /\bcontainer\b/, /\bcompose\b/, /\bnginx\b/] },
               { label: 'area:frontend',     patterns: [/\breact\b/, /\bnext\.?js\b/, /\btailwind\b/, /\bi18n\b/] },
               { label: 'area:backend',      patterns: [/\bgolang\b/, /\bgo service\b/, /\bgorm\b/] },
               { label: 'area:dependencies', patterns: [/\bdependabot\b/, /\bdependency\b/, /\bgo\.mod\b/, /\bpackage\.json\b/] },

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -118,7 +118,8 @@ jobs:
               /\bremove\b/,
               /\bimprove\b/,
               /\bintroduce\b/,
-              /\bsupport\b/
+              /\badd support\b/,
+              /\bsupport for\b/
             ]
 
             const titlePrefixes = {
@@ -270,7 +271,11 @@ jobs:
             }
             const existingTypedCategory = typedPrefixCategoryMap[existingTypedPrefix] || ''
             const hasStaleDocsPrefix = existingTypedPrefix === 'docs' && Boolean(desiredPrefix)
-            const hasStaleTypedCategoryPrefix = hasStaleDocsPrefix || (Boolean(existingTypedCategory) && !labelsToApply.includes(existingTypedCategory) && Boolean(desiredPrefix))
+            const hasStaleTaskPrefix = existingTypedPrefix === 'task' && Boolean(desiredPrefix)
+            const hasStaleTypedCategoryPrefix =
+              hasStaleDocsPrefix ||
+              hasStaleTaskPrefix ||
+              (Boolean(existingTypedCategory) && !labelsToApply.includes(existingTypedCategory) && Boolean(desiredPrefix))
             const bodyCandidate = extractCandidateTitleFromBody(issue.body || '')
             const rawStrippedTitle = currentTitle.replace(/^\[[^\]]+\]\s*/, '').trim()
             const baseTitle = isWeakTitle(currentTitle)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       has_migration_changes: ${{ steps.filter.outputs.migrations }}
       has_calm_changes: ${{ steps.filter.outputs.calm }}
       has_docs_user_changes: ${{ steps.filter.outputs.docs_user }}
+      has_issue_labeling_changes: ${{ steps.filter.outputs.issue_labeling }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -59,6 +60,26 @@ jobs:
               - 'docs/architecture-as-code/**'
             docs_user:
               - 'docs-user/**'
+            issue_labeling:
+              - '.github/workflows/auto-label-issues.yml'
+              - '.github/tests/auto-label-issues*.test.mjs'
+
+  test-issue-auto-labeling:
+    name: Issue Auto-labeling Tests
+    runs-on: ubuntu-latest
+    needs: [detect-file-changes]
+    if: ${{ needs.detect-file-changes.outputs.has_issue_labeling_changes == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Run auto-labeling regression tests
+        run: node --test .github/tests/auto-label-issues*.test.mjs
 
   detect-environment:
     name: Detect Target Environment

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -138,6 +138,7 @@
     "cusip",
     "Datenservice",
     "dbname",
+    "dedupe",
     "deltasyncinterval",
     "deque",
     "distroless",


### PR DESCRIPTION
## Summary

Comprehensive fix for several false-positive and false-negative issues in the `auto-label-issues` workflow, culminating in the deprecation of the `documentation` category label.

### Root Cause

The workflow had two core problems:
1. A **default `question` fallback** that labelled any issue as `[Question]` when nothing else matched
2. **Overly broad patterns** (bare `\bhow\b`, `\bwhy\b`, `\bhelp\b`) that matched action-oriented feature requests

Secondary issues:
- `area:database` matched bare `migration` keyword, hitting CI-related issues
- No category priority sorting meant `documentation` could beat `bug`/`security` for title prefix assignment
- Stale `[Docs]` prefixes on issues could not auto-correct when a stronger category was inferred

### Changes

#### `auto-label-issues.yml`

- Remove default question fallback
- Add `actionIntentPatterns` guard (add, implement, create, enable, allow, update, refactor, migrate, remove, improve, introduce, support)
- Reorder rules: `area:ci` now checked before `area:database`
- Tighten `area:database` patterns: require DB-specific context alongside migration keywords
- Add `categoryPriority` sort: `['bug', 'security', 'performance', 'enhancement', 'question']`
- Add stale-prefix override logic (`hasStaleDocsPrefix`, `hasStaleTypedCategoryPrefix`)
- Remove `documentation` label rule entirely - deprecated in favour of `area:docs`
- Add `desiredPrefix`/`effectivePrefix` split to preserve existing non-category prefixes

#### `.github/tests/` (new - 4 files, 9 tests)

| File | Tests |
|------|-------|
| `auto-label-issues.question-classification.test.mjs` | 3 |
| `auto-label-issues.area-classification.test.mjs` | 2 |
| `auto-label-issues.primary-category.test.mjs` | 2 |
| `auto-label-issues.documentation-classification.test.mjs` | 2 |

#### `.vscode/settings.json`

- Added `dedupe` to spell-check dictionary

### Bulk remediation (already applied to GitHub issues)

- Removed false-positive `question` label from 9 open and 14 closed issues
- Migrated 15 closed `documentation`-labelled issues to `area:docs`
- Fixed ~32 closed issues with `status: triage` -> `status: done`
- Corrected `area:database` -> `area:ci` on issue #295
- Deleted the `documentation` label from the repository

Refs #404