### PR TITLE
Add frontend reset workflows and fix runtime npm in frontend image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,32 +169,44 @@ docker-main-restart: ## Restart main branch environment
 	fi
 
 docker-main-frontend-reset: ## Reset main frontend node_modules/.next volumes and recreate the frontend service
-ifeq ($(OS),Windows_NT)
-	pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/reset-frontend-state.ps1 -Environment main
-else
-	bash scripts/reset-frontend-state.sh main
-endif
+	@if command -v bash >/dev/null 2>&1; then \
+		bash scripts/reset-frontend-state.sh main; \
+	elif command -v pwsh >/dev/null 2>&1; then \
+		pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/reset-frontend-state.ps1 -Environment main; \
+	else \
+		echo "❌ Neither 'bash' nor 'pwsh' was found. Cannot reset main frontend state."; \
+		exit 1; \
+	fi
 
 docker-dev-frontend-reset: ## Reset dev frontend node_modules/.next volumes and recreate the frontend service
-ifeq ($(OS),Windows_NT)
-	pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/reset-frontend-state.ps1 -Environment dev
-else
-	bash scripts/reset-frontend-state.sh dev
-endif
+	@if command -v bash >/dev/null 2>&1; then \
+		bash scripts/reset-frontend-state.sh dev; \
+	elif command -v pwsh >/dev/null 2>&1; then \
+		pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/reset-frontend-state.ps1 -Environment dev; \
+	else \
+		echo "❌ Neither 'bash' nor 'pwsh' was found. Cannot reset dev frontend state."; \
+		exit 1; \
+	fi
 
 docker-uat-frontend-reset: ## Recreate UAT frontend service with a fresh image
-ifeq ($(OS),Windows_NT)
-	pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/reset-frontend-state.ps1 -Environment uat
-else
-	bash scripts/reset-frontend-state.sh uat
-endif
+	@if command -v bash >/dev/null 2>&1; then \
+		bash scripts/reset-frontend-state.sh uat; \
+	elif command -v pwsh >/dev/null 2>&1; then \
+		pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/reset-frontend-state.ps1 -Environment uat; \
+	else \
+		echo "❌ Neither 'bash' nor 'pwsh' was found. Cannot reset uat frontend state."; \
+		exit 1; \
+	fi
 
 docker-prod-frontend-reset: ## Recreate prod frontend service with a fresh image
-ifeq ($(OS),Windows_NT)
-	pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/reset-frontend-state.ps1 -Environment prod
-else
-	bash scripts/reset-frontend-state.sh prod
-endif
+	@if command -v bash >/dev/null 2>&1; then \
+		bash scripts/reset-frontend-state.sh prod; \
+	elif command -v pwsh >/dev/null 2>&1; then \
+		pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/reset-frontend-state.ps1 -Environment prod; \
+	else \
+		echo "❌ Neither 'bash' nor 'pwsh' was found. Cannot reset prod frontend state."; \
+		exit 1; \
+	fi
 
 # Main branch environment (intraday development/fixes)
 docker-main-up: ## Start main branch environment (ports: 48080, 43000, 45432)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .PHONY: help build run test clean migrate-up migrate-down docker-up docker-down
 .PHONY: docker-main-up docker-main-down docker-main-rebuild-safe docker-dev-up docker-dev-down docker-dev-rebuild-safe docker-uat-up docker-uat-down docker-uat-rebuild-safe docker-prod-up docker-prod-down docker-prod-rebuild-safe
 .PHONY: docker-all-up docker-all-down docker-all-status validate-env
+.PHONY: docker-main-frontend-reset docker-dev-frontend-reset docker-uat-frontend-reset docker-prod-frontend-reset
 .PHONY: lint lint-docs lint-docs-fix docs-check docs-check-fix lint-all install-hooks settings-sort settings-sort-check
 .PHONY: smoke-api smoke-ssi cleanup-stale-translations docs-user-install docs-user-ci-install docs-user-build docs-user-check docs-user-dev
 
@@ -166,6 +167,34 @@ docker-main-restart: ## Restart main branch environment
 		echo "❌ Neither 'bash' nor 'pwsh' was found. Cannot run main compose wrapper."; \
 		exit 1; \
 	fi
+
+docker-main-frontend-reset: ## Reset main frontend node_modules/.next volumes and recreate the frontend service
+ifeq ($(OS),Windows_NT)
+	pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/reset-frontend-state.ps1 -Environment main
+else
+	bash scripts/reset-frontend-state.sh main
+endif
+
+docker-dev-frontend-reset: ## Reset dev frontend node_modules/.next volumes and recreate the frontend service
+ifeq ($(OS),Windows_NT)
+	pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/reset-frontend-state.ps1 -Environment dev
+else
+	bash scripts/reset-frontend-state.sh dev
+endif
+
+docker-uat-frontend-reset: ## Recreate UAT frontend service with a fresh image
+ifeq ($(OS),Windows_NT)
+	pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/reset-frontend-state.ps1 -Environment uat
+else
+	bash scripts/reset-frontend-state.sh uat
+endif
+
+docker-prod-frontend-reset: ## Recreate prod frontend service with a fresh image
+ifeq ($(OS),Windows_NT)
+	pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/reset-frontend-state.ps1 -Environment prod
+else
+	bash scripts/reset-frontend-state.sh prod
+endif
 
 # Main branch environment (intraday development/fixes)
 docker-main-up: ## Start main branch environment (ports: 48080, 43000, 45432)

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -31,25 +31,24 @@ RUN npm run build
 # Runtime stage
 FROM ${DOCKER_LIBRARY}/node:22-alpine3.21
 
-# Security: keep OpenSSL patched using latest package available in Alpine repo.
+# Security: keep OpenSSL patched using latest package available in Alpine repo
+# and install the patched npm CLI in the runtime image.
 # security-scan-managed
 # hadolint ignore=DL3018
-RUN apk add --no-cache --upgrade libssl3
-
-# Install the patched npm directly in the runtime image so maintenance commands
-# like `npm install` work reliably when the container is bind-mounted for local dev.
-RUN npm install -g npm@11.12.0
+RUN apk add --no-cache --upgrade libssl3 \
+	&& npm install -g npm@11.12.0
 
 WORKDIR /app
 
-# Copy package files and node_modules from builder (no reinstall - faster, avoids npm registry timeouts)
+# Copy package files and application dependencies from the builder for reproducibility
+# and to avoid a second install of app dependencies in the runtime stage.
+# Note: the runtime image still fetches the patched npm CLI above via `npm install -g`.
 COPY package*.json ./
 COPY --from=builder /app/node_modules ./node_modules
 
 # Copy build output
 COPY --from=builder /app/.next ./.next
-# Only copy public if it exists
-RUN if [ -d /app/public ]; then cp -r /app/public ./public; fi
+COPY --from=builder /app/public ./public
 
 EXPOSE 3000
 

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -36,14 +36,15 @@ FROM ${DOCKER_LIBRARY}/node:22-alpine3.21
 # hadolint ignore=DL3018
 RUN apk add --no-cache --upgrade libssl3
 
+# Install the patched npm directly in the runtime image so maintenance commands
+# like `npm install` work reliably when the container is bind-mounted for local dev.
+RUN npm install -g npm@11.12.0
+
 WORKDIR /app
 
 # Copy package files and node_modules from builder (no reinstall - faster, avoids npm registry timeouts)
 COPY package*.json ./
 COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /usr/local/bin/npm /usr/local/bin/npm
-COPY --from=builder /usr/local/bin/npx /usr/local/bin/npx
-COPY --from=builder /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
 
 # Copy build output
 COPY --from=builder /app/.next ./.next

--- a/scripts/reset-frontend-state.ps1
+++ b/scripts/reset-frontend-state.ps1
@@ -1,0 +1,102 @@
+#!/usr/bin/env pwsh
+
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("main", "dev", "uat", "prod")]
+    [string]$Environment
+)
+
+$ErrorActionPreference = "Stop"
+
+$gitCommonDir = (& git rev-parse --path-format=absolute --git-common-dir).Trim()
+if (-not $gitCommonDir) {
+    throw "Unable to resolve git common dir. Run this script inside the repository or one of its worktrees."
+}
+
+$repoRoot = Split-Path -Parent $gitCommonDir
+
+$config = switch ($Environment) {
+    "main" {
+        @{
+            ProjectName = "axiom-main"
+            EnvFile = Join-Path $repoRoot ".env.main"
+            ComposeFile = Join-Path $repoRoot "docker-compose.main.yml"
+            HasFrontendVolumes = $true
+            UseMainWrapper = $true
+            NodeModulesVolume = "axiom-main_frontend_node_modules_main"
+            NextVolume = "axiom-main_frontend_next_main"
+        }
+    }
+    "dev" {
+        @{
+            ProjectName = "axiom-dev"
+            EnvFile = Join-Path $repoRoot ".env.dev"
+            ComposeFile = Join-Path $repoRoot "docker-compose.dev.yml"
+            HasFrontendVolumes = $true
+            UseMainWrapper = $false
+            NodeModulesVolume = "axiom-dev_frontend_node_modules_dev"
+            NextVolume = "axiom-dev_frontend_next_dev"
+        }
+    }
+    "uat" {
+        @{
+            ProjectName = "axiom-uat"
+            EnvFile = Join-Path $repoRoot ".env.uat"
+            ComposeFile = Join-Path $repoRoot "docker-compose.uat.yml"
+            HasFrontendVolumes = $false
+            UseMainWrapper = $false
+        }
+    }
+    "prod" {
+        @{
+            ProjectName = "axiom-prod"
+            EnvFile = Join-Path $repoRoot ".env.prod"
+            ComposeFile = Join-Path $repoRoot "docker-compose.prod.yml"
+            HasFrontendVolumes = $false
+            UseMainWrapper = $false
+        }
+    }
+}
+
+if (-not (Test-Path $config.EnvFile)) {
+    throw "Missing env file: $($config.EnvFile)"
+}
+if (-not (Test-Path $config.ComposeFile)) {
+    throw "Missing compose file: $($config.ComposeFile)"
+}
+
+$frontendContainer = "$($config.ProjectName)-frontend"
+$composeBaseArgs = @(
+    "--project-directory", $repoRoot,
+    "--env-file", $config.EnvFile,
+    "-f", $config.ComposeFile
+)
+
+Write-Host "Stopping $Environment frontend service..."
+if ($config.UseMainWrapper) {
+    & (Join-Path $repoRoot "scripts/run-main-compose.ps1") stop -t 45 frontend
+} else {
+    & docker compose @composeBaseArgs stop -t 45 frontend
+}
+
+Write-Host "Removing frontend container to release volumes..."
+& docker rm -f $frontendContainer *> $null
+
+if ($config.HasFrontendVolumes) {
+    Write-Host "Removing stale frontend volumes..."
+    & docker volume rm $config.NodeModulesVolume $config.NextVolume *> $null
+} else {
+    Write-Host "No dedicated frontend node_modules/.next volumes defined for '$Environment'; skipping volume removal."
+}
+
+Write-Host "Rebuilding and recreating $Environment frontend service..."
+if ($config.UseMainWrapper) {
+    & (Join-Path $repoRoot "scripts/run-main-compose.ps1") up -d --build frontend
+} else {
+    & docker compose @composeBaseArgs up -d --build frontend
+}
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to recreate $Environment frontend service."
+}
+
+Write-Host "$Environment frontend state reset complete."

--- a/scripts/reset-frontend-state.sh
+++ b/scripts/reset-frontend-state.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <main|dev|uat|prod>" >&2
+  exit 1
+fi
+
+environment="$1"
+
+if ! git_common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"; then
+  echo "Unable to resolve git common dir. Run this script inside the repository or one of its worktrees." >&2
+  exit 1
+fi
+
+repo_root="$(dirname "$git_common_dir")"
+
+project_name=""
+env_file=""
+compose_file=""
+has_frontend_volumes="false"
+use_main_wrapper="false"
+node_modules_volume=""
+next_volume=""
+
+case "$environment" in
+  main)
+    project_name="axiom-main"
+    env_file="$repo_root/.env.main"
+    compose_file="$repo_root/docker-compose.main.yml"
+    has_frontend_volumes="true"
+    use_main_wrapper="true"
+    node_modules_volume="axiom-main_frontend_node_modules_main"
+    next_volume="axiom-main_frontend_next_main"
+    ;;
+  dev)
+    project_name="axiom-dev"
+    env_file="$repo_root/.env.dev"
+    compose_file="$repo_root/docker-compose.dev.yml"
+    has_frontend_volumes="true"
+    use_main_wrapper="false"
+    node_modules_volume="axiom-dev_frontend_node_modules_dev"
+    next_volume="axiom-dev_frontend_next_dev"
+    ;;
+  uat)
+    project_name="axiom-uat"
+    env_file="$repo_root/.env.uat"
+    compose_file="$repo_root/docker-compose.uat.yml"
+    ;;
+  prod)
+    project_name="axiom-prod"
+    env_file="$repo_root/.env.prod"
+    compose_file="$repo_root/docker-compose.prod.yml"
+    ;;
+  *)
+    echo "Unsupported environment '$environment'. Use one of: main, dev, uat, prod." >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! -f "$env_file" ]]; then
+  echo "Missing env file: $env_file" >&2
+  exit 1
+fi
+if [[ ! -f "$compose_file" ]]; then
+  echo "Missing compose file: $compose_file" >&2
+  exit 1
+fi
+
+frontend_container="$project_name-frontend"
+run_main_compose="$repo_root/scripts/run-main-compose.sh"
+
+compose_args=(
+  --project-directory "$repo_root"
+  --env-file "$env_file"
+  -f "$compose_file"
+)
+
+echo "Stopping $environment frontend service..."
+if [[ "$use_main_wrapper" == "true" ]]; then
+  "$run_main_compose" stop -t 45 frontend
+else
+  docker compose "${compose_args[@]}" stop -t 45 frontend
+fi
+
+echo "Removing frontend container to release volumes..."
+docker rm -f "$frontend_container" >/dev/null 2>&1 || true
+
+if [[ "$has_frontend_volumes" == "true" ]]; then
+  echo "Removing stale frontend volumes..."
+  docker volume rm "$node_modules_volume" "$next_volume" >/dev/null 2>&1 || true
+else
+  echo "No dedicated frontend node_modules/.next volumes defined for '$environment'; skipping volume removal."
+fi
+
+echo "Rebuilding and recreating $environment frontend service..."
+if [[ "$use_main_wrapper" == "true" ]]; then
+  "$run_main_compose" up -d --build frontend
+else
+  docker compose "${compose_args[@]}" up -d --build frontend
+fi
+
+echo "$environment frontend state reset complete."


### PR DESCRIPTION
## Summary
This PR addresses frontend container drift issues caused by stale runtime state and a broken runtime npm installation.

### Changes
- Add cross-environment frontend reset scripts:
  - scripts/reset-frontend-state.ps1
  - scripts/reset-frontend-state.sh
- Add make targets for reset operations:
  - docker-main-frontend-reset
  - docker-dev-frontend-reset
  - docker-uat-frontend-reset
  - docker-prod-frontend-reset
- Fix docker/Dockerfile.frontend runtime stage:
  - install patched npm@11.12.0 directly in runtime image
  - stop copying npm binaries/modules from builder stage

## Validation
- make -n docker-main-frontend-reset docker-dev-frontend-reset docker-uat-frontend-reset docker-prod-frontend-reset
- try { (Invoke-WebRequest -UseBasicParsing http://localhost:43000).StatusCode } catch { $_.Exception.Response.StatusCode.value__ } returned 200

## Notes
- This change is operational/infra focused and does not alter backend business logic.