### PR TITLE
fix: backport PR #436 Copilot thread fixes to main

### DIFF
--- a/frontend/app/lib/api-base.test.ts
+++ b/frontend/app/lib/api-base.test.ts
@@ -8,8 +8,8 @@ describe('api-base', () => {
   })
 
   it('uses same-origin base in the browser', () => {
-    expect(resolveApiBaseUrl(true)).toBe('')
-    expect(getApiBaseUrl()).toBe('')
+    expect(resolveApiBaseUrl(true)).toBe(window.location.origin)
+    expect(getApiBaseUrl()).toBe(window.location.origin)
   })
 
   it('uses INTERNAL_API_PROXY_TARGET for server-side calls when configured', () => {

--- a/frontend/app/lib/api-base.ts
+++ b/frontend/app/lib/api-base.ts
@@ -1,7 +1,8 @@
 export function resolveApiBaseUrl(isBrowser: boolean = typeof window !== 'undefined'): string {
   if (isBrowser) {
     // Browser calls stay same-origin and are forwarded by Next.js rewrites.
-    return ''
+    // Using origin keeps user-facing diagnostics readable.
+    return window.location.origin
   }
 
   return process.env.INTERNAL_API_PROXY_TARGET || 'http://localhost:18080'

--- a/frontend/app/lib/useCollectionCount.test.ts
+++ b/frontend/app/lib/useCollectionCount.test.ts
@@ -23,7 +23,7 @@ describe('useCollectionCount', () => {
       expect(result.current.count).toBe(3)
     })
 
-    expect(fetchMock).toHaveBeenCalledWith('/api/v1/countries', { cache: 'no-store' })
+    expect(fetchMock).toHaveBeenCalledWith(`${window.location.origin}/api/v1/countries`, { cache: 'no-store' })
     unmount()
   })
 

--- a/scripts/post-gh-comment-safe.ps1
+++ b/scripts/post-gh-comment-safe.ps1
@@ -111,21 +111,21 @@ $resolvedBodyFile = if ($PSCmdlet.ParameterSetName -like '*ByFile') {
     Join-Path ([System.IO.Path]::GetTempPath()) ("gh-comment-{0}.md" -f ([Guid]::NewGuid().ToString('N')))
 }
 
+$targetNumber = if ($TargetType -eq 'issue') { $IssueNumber } else { $PrNumber }
+if ($DryRun) {
+    Write-Host "[safe-comment] dry-run target=$TargetType number=$targetNumber repo=$Repo"
+    Write-Host "[safe-comment] body_file=$resolvedBodyFile"
+    return
+}
+
 $createdTemp = $false
 if ($PSCmdlet.ParameterSetName -like '*ByText') {
     [System.IO.File]::WriteAllText($resolvedBodyFile, $Body, [System.Text.UTF8Encoding]::new($false))
     $createdTemp = $true
 }
 
-$targetNumber = if ($TargetType -eq 'issue') { $IssueNumber } else { $PrNumber }
 $expectedRaw = Get-Content -LiteralPath $resolvedBodyFile -Raw
 $expectedNormalized = Normalize-Text -Text $expectedRaw
-
-if ($DryRun) {
-    Write-Host "[safe-comment] dry-run target=$TargetType number=$targetNumber repo=$Repo"
-    Write-Host "[safe-comment] body_file=$resolvedBodyFile"
-    exit 0
-}
 
 $viewer = gh api user --jq .login
 if ([string]::IsNullOrWhiteSpace($viewer)) {


### PR DESCRIPTION
## Summary
Backport the review-thread fixes implemented on PR #436 into main so future main -> dev promotions do not overwrite them.

## Changes
- frontend/app/lib/api-base.ts: return window.location.origin in browser context for displayable API base text.
- frontend/app/lib/api-base.test.ts: align browser expectations with origin behavior.
- scripts/post-gh-comment-safe.ps1: move dry-run guard before temp file writes and use return instead of exit 0.

## Validation
- npm test -- app/lib/api-base.test.ts
- pwsh -File scripts/post-gh-comment-safe.ps1 -DryRun

Refs #436