### PR TITLE
fix: backport PR #438 review fixes to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,11 @@ worktree-local empty database directory.
 
 ```bash
 # Works from repo root or any git worktree
+# Windows / PowerShell
 ./scripts/run-main-compose.ps1 up -d --build
+
+# Linux / macOS
+./scripts/run-main-compose.sh up -d --build
 ```
 
 When testing PRs/worktrees against the `main` compose file, avoid reusing `.env.main` across multiple folders.

--- a/frontend/app/components/PageHeader.tsx
+++ b/frontend/app/components/PageHeader.tsx
@@ -65,7 +65,7 @@ export default function PageHeader({
       <div>
         {dashboardPageSection && (
           <nav
-            aria-label={t('nav.breadcrumbs', 'Breadcrumbs')}
+            aria-label={t('nav.breadcrumbs')}
             className="mb-3 overflow-x-auto"
           >
             <ol className="flex min-w-max items-center gap-2 text-xs sm:text-sm theme-text-muted">


### PR DESCRIPTION
## Summary
Backport the review-thread fixes from PR #438 into main so future promotions do not overwrite them.

## Backported Changes
- README.md: document both PowerShell and Bash main-compose wrapper scripts.
- frontend/app/components/PageHeader.tsx: remove the redundant nav.breadcrumbs fallback.

## Notes
- The useCollectionCount test expectation fix from PR #438 was already present on main, so it did not need to be backported again.

## Validation
- npm test -- app/lib/useCollectionCount.test.ts app/lib/api-base.test.ts
- make docs-check

Refs #438