### PR TITLE
ci: add CodeQL workflow for nested Go module

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,71 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - uat
+      - prod
+  pull_request:
+    branches:
+      - main
+      - dev
+      - uat
+      - prod
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: manual
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Build backend for CodeQL
+        if: matrix.language == 'go'
+        working-directory: backend
+        run: |
+          go mod download
+          go build ./...
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,18 +45,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
-        with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
-
       - name: Set up Go
         if: matrix.language == 'go'
         uses: actions/setup-go@v5
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
 
       - name: Build backend for CodeQL
         if: matrix.language == 'go'

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -34,6 +34,12 @@ directly (the token has no `security_events` scope), and documents three approac
 bridge this gap: paste-as-context, the weekly `security-report.yml` workflow, and a
 fine-grained PAT stored as a repository secret.
 
+### [CodeQL Workflow](../../.github/workflows/codeql.yml)
+
+Advanced CodeQL configuration for this monorepo layout. The Go analysis runs from the
+`backend/` module with an explicit build step (`go mod download && go build ./...`)
+because GitHub default setup does not correctly process nested Go modules from repo root.
+
 ## Quick Reference
 
 For a high-level summary of security updates, see [SECURITY_UPDATE_SUMMARY.md](SECURITY_UPDATE_SUMMARY.md).
@@ -47,6 +53,7 @@ The project now includes a comprehensive automated security update system:
 - **Consolidated PRs** - Single PR with all security fixes
 - **Version tracking** - Audit trail in `.github/security-versions.yml`
 - **Dependabot integration** - Base image updates
+- **CodeQL advanced setup** - Go scanning builds from `backend/` instead of repo root
 
 See [AUTOMATED_UPDATES.md](AUTOMATED_UPDATES.md) for complete documentation.
 
@@ -57,5 +64,7 @@ See [AUTOMATED_UPDATES.md](AUTOMATED_UPDATES.md) for complete documentation.
 - [Docker Best Practices](../../.github/instructions/containerization-docker-best-practices.instructions.md) -
   Container security guidelines
 - [Security Scan Enhanced Workflow](../../.github/workflows/security-scan-enhanced.yml) - Automated security scanning
+- [CodeQL Workflow](../../.github/workflows/codeql.yml) - Advanced CodeQL analysis for Go, JavaScript/TypeScript,
+  and GitHub Actions
 - [Dependabot Configuration](../../.github/dependabot.yml) - Dependency monitoring
 - [Security Version Tracking](../../.github/security-versions.yml) - Pinned versions audit trail

--- a/llms.txt
+++ b/llms.txt
@@ -144,6 +144,8 @@ WebSocket support, rate limiting, Prometheus metrics, and containerized deployme
   branches
 - [CI Workflow](.github/workflows/ci.yml): Unified CI pipeline keyed off branch names for
   environment detection (main, dev, uat, prod)
+- [CodeQL Workflow](.github/workflows/codeql.yml): Advanced CodeQL analysis; Go scanning builds from
+  `backend/` so nested-module extraction works reliably
 - [Nightly Promotion Workflow](.github/workflows/promote-main-to-dev.yml): Scheduled workflow that
   opens a promotion PR from main → dev each night to prevent branch drift
 - [Weekly Promotion Workflow](.github/workflows/promote-dev-to-uat.yml): Scheduled workflow that


### PR DESCRIPTION
## Summary
Add a committed advanced CodeQL workflow for this monorepo so Go analysis builds from the `backend/` module instead of relying on GitHub default setup from repo root.

## What changed
- add `.github/workflows/codeql.yml` for CodeQL analysis of Go, JavaScript/TypeScript, and GitHub Actions
- configure the Go matrix entry to run `go mod download` and `go build ./...` from `backend/`
- document the nested-module CodeQL requirement in `docs/security/README.md`
- add the new workflow to `llms.txt`

## Why
GitHub CodeQL default setup reports `Go files were found but not processed` for this repository because the Go module lives under `backend/` rather than repository root.

## Validation
- `cd backend && go build ./...`
- `npx --yes markdownlint-cli2 --config .markdownlint.yaml docs/security/README.md llms.txt`

- [x] no linked issue
Reason: repository CI/security configuration fix
