### PR TITLE
test(frontend): replace hoisted vi.unmock calls in theme-controls test

### DIFF
--- a/frontend/app/components/theme-controls.test.tsx
+++ b/frontend/app/components/theme-controls.test.tsx
@@ -195,11 +195,11 @@ async function loadThemeToggle(options?: {
 
 afterEach(() => {
   vi.restoreAllMocks()
-  vi.unmock('react')
-  vi.unmock('react-i18next')
-  vi.unmock('../lib/useDeferredStringPreference')
-  vi.unmock('../lib/theme')
-  vi.unmock('./PreferenceSavePrompt')
+  vi.doUnmock('react')
+  vi.doUnmock('react-i18next')
+  vi.doUnmock('../lib/useDeferredStringPreference')
+  vi.doUnmock('../lib/theme')
+  vi.doUnmock('./PreferenceSavePrompt')
   delete (globalThis as { document?: unknown }).document
   delete (globalThis as { Node?: unknown }).Node
 })


### PR DESCRIPTION
## Summary
- replaces i.unmock(...) calls inside fterEach with i.doUnmock(...) in 	heme-controls.test.tsx
- removes Vitest hoist warnings about non-top-level unmock calls while preserving cleanup behavior

## Validation
- 
pm test -- app/components/theme-controls.test.tsx

## Notes
- no runtime code changes; test-only follow-up from PR #447