### PR TITLE
feat(db): enforce user_entity_links_audit FK to user_entity_links

### DIFF
--- a/backend/migrations/000067_add_fk_user_entity_links_audit.down.sql
+++ b/backend/migrations/000067_add_fk_user_entity_links_audit.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE IF EXISTS user_entity_links_audit
+DROP CONSTRAINT IF EXISTS fk_user_entity_links_audit_link_id;
+
+COMMENT ON COLUMN user_entity_links_audit.user_entity_link_id IS
+'References user_entity_links.id in application logic (no DB foreign key constraint).';

--- a/backend/migrations/000067_add_fk_user_entity_links_audit.down.sql
+++ b/backend/migrations/000067_add_fk_user_entity_links_audit.down.sql
@@ -2,4 +2,4 @@ ALTER TABLE IF EXISTS user_entity_links_audit
 DROP CONSTRAINT IF EXISTS fk_user_entity_links_audit_link_id;
 
 COMMENT ON COLUMN user_entity_links_audit.user_entity_link_id IS
-'References user_entity_links.id in application logic (no DB foreign key constraint).';
+'Foreign key to user_entity_links.id.';

--- a/backend/migrations/000067_add_fk_user_entity_links_audit.up.sql
+++ b/backend/migrations/000067_add_fk_user_entity_links_audit.up.sql
@@ -1,15 +1,29 @@
 DO $$
+DECLARE
+    orphan_count BIGINT;
 BEGIN
+    SELECT COUNT(*)
+    INTO orphan_count
+    FROM user_entity_links_audit a
+    LEFT JOIN user_entity_links l ON l.id = a.user_entity_link_id
+    WHERE l.id IS NULL;
+
+    IF orphan_count > 0 THEN
+        RAISE EXCEPTION 'Cannot add fk_user_entity_links_audit_link_id: found % orphan audit rows', orphan_count;
+    END IF;
+
     IF NOT EXISTS (
         SELECT 1
         FROM pg_constraint
         WHERE conname = 'fk_user_entity_links_audit_link_id'
+          AND conrelid = 'user_entity_links_audit'::regclass
     ) THEN
         ALTER TABLE user_entity_links_audit
         ADD CONSTRAINT fk_user_entity_links_audit_link_id
         FOREIGN KEY (user_entity_link_id)
         REFERENCES user_entity_links (id)
-        ON DELETE RESTRICT;
+        ON DELETE RESTRICT
+        NOT VALID;
     END IF;
 END$$;
 

--- a/backend/migrations/000067_add_fk_user_entity_links_audit.up.sql
+++ b/backend/migrations/000067_add_fk_user_entity_links_audit.up.sql
@@ -1,0 +1,17 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_user_entity_links_audit_link_id'
+    ) THEN
+        ALTER TABLE user_entity_links_audit
+        ADD CONSTRAINT fk_user_entity_links_audit_link_id
+        FOREIGN KEY (user_entity_link_id)
+        REFERENCES user_entity_links (id)
+        ON DELETE RESTRICT;
+    END IF;
+END$$;
+
+COMMENT ON COLUMN user_entity_links_audit.user_entity_link_id IS
+'Foreign key to user_entity_links.id. ON DELETE RESTRICT preserves audit integrity.';

--- a/backend/migrations/000068_validate_fk_user_entity_links_audit.down.sql
+++ b/backend/migrations/000068_validate_fk_user_entity_links_audit.down.sql
@@ -1,0 +1,3 @@
+-- Validation cannot be rolled back independently.
+-- Constraint lifecycle rollback is handled by 000067 down migration.
+SELECT 1;

--- a/backend/migrations/000068_validate_fk_user_entity_links_audit.up.sql
+++ b/backend/migrations/000068_validate_fk_user_entity_links_audit.up.sql
@@ -1,0 +1,13 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_user_entity_links_audit_link_id'
+          AND conrelid = 'user_entity_links_audit'::regclass
+          AND NOT convalidated
+    ) THEN
+        ALTER TABLE user_entity_links_audit
+        VALIDATE CONSTRAINT fk_user_entity_links_audit_link_id;
+    END IF;
+END$$;


### PR DESCRIPTION
## Follow-up: enforce audit referential integrity

This PR adds a dedicated migration to enforce a DB-level FK from user_entity_links_audit.user_entity_link_id to user_entity_links.id.

### Why now
- User-entity links are soft-revoked/unrevoked and are not physically deleted in normal operation.
- Audit rows should maintain enforced referential integrity.

### Changes
- Added 000067_add_fk_user_entity_links_audit.up.sql
  - Adds constraint fk_user_entity_links_audit_link_id
  - ON DELETE RESTRICT
  - Updates column comment to explicitly document FK behavior
- Added 000067_add_fk_user_entity_links_audit.down.sql
  - Drops the FK constraint
  - Restores non-FK comment text

Refs #483
