### PR TITLE
fix: prevent duplicate automated security update PRs

### DIFF
--- a/.github/workflows/security-scan-enhanced.yml
+++ b/.github/workflows/security-scan-enhanced.yml
@@ -393,9 +393,40 @@ jobs:
           git config --local --unset-all http.https://github.com/.extraheader || true
           git config --global --unset-all http.https://github.com/.extraheader || true
 
+      - name: Check existing open automated security PR for main
+        id: check-existing-pr
+        if: steps.parse-vulns.outputs.has_updates == 'true' && (github.event.inputs.create_pr == 'true' || github.event_name != 'workflow_dispatch')
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const openPrs = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              base: 'main',
+              per_page: 100
+            });
+
+            const duplicate = openPrs.find((pr) => {
+              const titleMatches = (pr.title || '').startsWith('🔒 Automated Security Updates -');
+              const headMatches = (pr.head && pr.head.ref || '').startsWith('security/automated-updates-');
+              return titleMatches || headMatches;
+            });
+
+            if (duplicate) {
+              core.notice(`Found existing open automated security PR: ${duplicate.html_url}`);
+              core.setOutput('should_create_pr', 'false');
+              core.setOutput('existing_pr_url', duplicate.html_url);
+            } else {
+              core.setOutput('should_create_pr', 'true');
+              core.setOutput('existing_pr_url', '');
+            }
+
       - name: Create Pull Request
         id: create-pr
-        if: steps.parse-vulns.outputs.has_updates == 'true' && (github.event.inputs.create_pr == 'true' || github.event_name != 'workflow_dispatch')
+        if: steps.parse-vulns.outputs.has_updates == 'true' && (github.event.inputs.create_pr == 'true' || github.event_name != 'workflow_dispatch') && steps.check-existing-pr.outputs.should_create_pr == 'true'
         continue-on-error: true
         uses: peter-evans/create-pull-request@v6
         with:
@@ -443,6 +474,11 @@ jobs:
               fi
             elif [ "${{ steps.create-pr.outcome }}" == "failure" ]; then
               echo "- PR creation: ⚠️ Failed (scan completed; create PR manually if needed)" >> $GITHUB_STEP_SUMMARY
+            elif [ "${{ steps.check-existing-pr.outputs.should_create_pr }}" == "false" ]; then
+              echo "- PR creation: ⏭️ Skipped (existing automated PR already open for main)" >> $GITHUB_STEP_SUMMARY
+              if [ -n "${{ steps.check-existing-pr.outputs.existing_pr_url }}" ]; then
+                echo "- Existing PR: ${{ steps.check-existing-pr.outputs.existing_pr_url }}" >> $GITHUB_STEP_SUMMARY
+              fi
             fi
           else
             echo "✅ No fixable vulnerabilities found" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/security-scan-enhanced.yml
+++ b/.github/workflows/security-scan-enhanced.yml
@@ -12,7 +12,7 @@ on:
         default: true
         type: boolean
   push:
-    branches: [main, dev]
+    branches: [main]
     paths:
       - 'docker/**'
       - 'backend/go.mod'
@@ -404,6 +404,7 @@ jobs:
           title: '🔒 Automated Security Updates - ${{ steps.parse-vulns.outputs.critical_count }} Critical, ${{ steps.parse-vulns.outputs.high_count }} High'
           body-path: 'pr_description.md'
           branch: 'security/automated-updates-${{ github.run_number }}'
+          base: 'main'
           delete-branch: true
           labels: |
             security

--- a/.github/workflows/security-scan-enhanced.yml
+++ b/.github/workflows/security-scan-enhanced.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          # Always run from main so automated security PRs are based on the canonical branch.
+          ref: main
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
## Summary
- prevent duplicate automated security-update PRs opened across branches
- restrict workflow push trigger to main
- set explicit PR base branch to main in create-pull-request
- skip PR creation when an open automated security PR for main already exists
- force checkout of main ref so workflow_dispatch cannot generate cross-branch PR content

## Why
PR #485 duplicated PR #482 payload due branch-triggered and dispatch-context behavior. This change enforces a single canonical PR stream and prevents duplicate or oversized security-update PRs.

## Validation
- inspected and hardened workflow trigger and PR creation config
- added existing-open-PR guard for main-targeted automated security PRs
- anchored checkout to `ref: main` to prevent non-main dispatch drift
- review thread feedback addressed and resolved
