### PR TITLE
feat: add fork-context skills for PR workflows and update instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -623,40 +623,45 @@ This repository configuration is designed to make AI coding agents immediately p
 
 ## PR Finalization Default (Team Preference)
 
-When an AI agent creates a pull request, it should complete standard PR hygiene automatically **without asking for confirmation**:
+**Use the `create-pull-request` skill to automatically handle PR creation with labels, reviewer assignment, and verification checklist.**
 
-1. Add appropriate labels following the three-namespace taxonomy:
-   - **Category** (optional, max one): `bug`, `enhancement`, `security`, `performance`, or `question` — add only when it conveys information not already implied by Area
-   - **Area** (required, exactly one): `area:backend`, `area:frontend`, `area:database`, `area:docs`,
-     `area:infra`, `area:ci`, `area:lei`, or `area:dependencies` — infer from the files touched OR let CI workflow auto-apply
-   - **Type** (optional secondary, one or two): `type:tests`, `type:refactor`, `type:chore`
-   - Add `automated` to mark AI-created items and `no-issue-needed` for PRs with no backing issue
-   - **Note**: The CI workflow (`auto-label-prs.yml`) automatically applies Area labels based on file paths. Do not manually add Area labels unless the auto-detection fails. Avoid duplicate semantics: do not add `documentation` when `area:docs` is present. Category labels are only needed when they are orthogonal to Area (e.g., `area:backend` change that is also a `security` fix should add `security`).
-   - **Replacement promotion PRs** (e.g., conflict-resolution branches like `fix/sync-dev-from-main-*` or
-     `fix/sync-uat-from-dev-*` that target `dev` or `uat` but do not originate from the required source branch):
-     apply `hotfix` **and** `no-issue-needed` at PR creation time — not reactively after CI flags them.
-     This is required because `Check Environment Branch Flow` blocks non-`main` branches targeting `dev`
-     unless the `hotfix` or `emergency` label is present, and `Check PR Issue Link` blocks PRs with no
-     issue reference unless `no-issue-needed` is present. Both checks will show
-   `Expected — Waiting for status to be reported` until the labels are applied, which triggers the
-   relevant workflows against the current PR head SHA without requiring an extra commit push.
-2. Request a reviewer (prefer `copilot-pull-request-reviewer` when available).
-3. Post a concise verification checklist comment relevant to the changed files.
-4. After each commit push to the PR branch, post a concise implementation summary comment that includes:
-   - what changed,
-   - what validation/tests were run,
-   - any follow-up actions or known limitations.
-   - If a push has no meaningful reviewer-facing delta, do not post a new summary comment.
-5. For each linked underlying issue (prefer `Refs #123`; use `Fixes/Closes #123` only when `#123` is confirmed to be
-   an issue and not a pull request),
-   post a concise issue update comment after each PR push (same per-push trigger as
-   [`instructions/copilot-pr-feedback-resolution.instructions.md`](instructions/copilot-pr-feedback-resolution.instructions.md))
-   that includes:
-   - implementation status,
-   - validation status,
-   - testing guidance for user/UAT verification,
-   - PR link.
-6. Do not ask whether to post the summary/checklist/issue-update comments; post them by default.
+The skill encodes these Axiom-specific workflows and posts all required comments automatically without asking for confirmation.
+
+### Manual Reference: Label Taxonomy
+
+If manually applying labels (not using the skill), follow this taxonomy:
+
+**Categories** (optional, max one):
+- `bug` — defect fix
+- `enhancement` — new feature or capability
+- `security` — security issue or fix
+- `performance` — performance improvement
+- `question` — unclear or needs clarification
+
+**Area** (required, exactly one):
+- `area:backend` — Go backend code changes
+- `area:frontend` — React/Next.js frontend changes
+- `area:database` — migrations, schema, or DB-related
+- `area:docs` — documentation and guides
+- `area:infra` — Docker, Docker Compose, infrastructure
+- `area:ci` — GitHub Actions workflows
+- `area:lei` — LEI-specific features
+- `area:dependencies` — dependency updates
+
+**Type** (optional secondary, one or two):
+- `type:tests` — test additions or modifications
+- `type:refactor` — code restructuring without behavior change
+- `type:chore` — maintenance, tooling
+
+**Special Labels**:
+- `automated` — mark AI-created PRs
+- `no-issue-needed` — for PRs with no backing issue
+- `hotfix` — for replacement promotion branches (`fix/sync-*` branches). Apply **with** `no-issue-needed` at PR creation time to bypass branch-flow checks.
+
+**Notes**:
+- The CI workflow (`auto-label-prs.yml`) auto-applies Area labels; do not manually duplicate.
+- Avoid duplicate semantics: do not add `documentation` when `area:docs` is present.
+- Category labels are only needed when orthogonal to Area (e.g., `area:backend` change that is also `security` should add `security`).
 
 ### Required Check Context Fallback (REQUIRED)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -623,7 +623,8 @@ This repository configuration is designed to make AI coding agents immediately p
 
 ## PR Finalization Default (Team Preference)
 
-**Use the `create-pull-request` skill to automatically handle PR creation with labels, reviewer assignment, and verification checklist.**
+**Use the `create-pull-request` skill to automatically handle PR creation with labels,
+reviewer assignment, and verification checklist.**
 
 The skill encodes these Axiom-specific workflows and posts all required comments automatically without asking for confirmation.
 
@@ -632,6 +633,7 @@ The skill encodes these Axiom-specific workflows and posts all required comments
 If manually applying labels (not using the skill), follow this taxonomy:
 
 **Categories** (optional, max one):
+
 - `bug` — defect fix
 - `enhancement` — new feature or capability
 - `security` — security issue or fix
@@ -639,6 +641,7 @@ If manually applying labels (not using the skill), follow this taxonomy:
 - `question` — unclear or needs clarification
 
 **Area** (required, exactly one):
+
 - `area:backend` — Go backend code changes
 - `area:frontend` — React/Next.js frontend changes
 - `area:database` — migrations, schema, or DB-related
@@ -649,16 +652,19 @@ If manually applying labels (not using the skill), follow this taxonomy:
 - `area:dependencies` — dependency updates
 
 **Type** (optional secondary, one or two):
+
 - `type:tests` — test additions or modifications
 - `type:refactor` — code restructuring without behavior change
 - `type:chore` — maintenance, tooling
 
 **Special Labels**:
+
 - `automated` — mark AI-created PRs
 - `no-issue-needed` — for PRs with no backing issue
 - `hotfix` — for replacement promotion branches (`fix/sync-*` branches). Apply **with** `no-issue-needed` at PR creation time to bypass branch-flow checks.
 
 **Notes**:
+
 - The CI workflow (`auto-label-prs.yml`) auto-applies Area labels; do not manually duplicate.
 - Avoid duplicate semantics: do not add `documentation` when `area:docs` is present.
 - Category labels are only needed when orthogonal to Area (e.g., `area:backend` change that is also `security` should add `security`).

--- a/.github/instructions/copilot-pr-comment-tracking.instructions.md
+++ b/.github/instructions/copilot-pr-comment-tracking.instructions.md
@@ -5,9 +5,17 @@ applyTo: '**'
 
 # Copilot PR Comment Thread ID Tracking
 
+## ⚡ Note: Use the Skill
+
+The `address-pr-comments` skill uses these patterns internally to track and
+manage comment IDs. You typically don't need to manually track IDs unless you're
+resolving feedback without the skill.
+
+---
+
 ## Overview
 
-When resolving multiple Copilot comments on a PR, tracking comment IDs and their
+When resolving multiple Copilot comments on a PR manually, tracking comment IDs and their
 resolution status prevents duplicate efforts and ensures no feedback is missed.
 This file provides structured patterns for identifying, organizing, and tracking
 comment threads.

--- a/.github/instructions/copilot-pr-feedback-resolution.instructions.md
+++ b/.github/instructions/copilot-pr-feedback-resolution.instructions.md
@@ -5,7 +5,23 @@ applyTo: '**'
 
 # Copilot PR Feedback Resolution Workflow
 
+## ⚡ Quick Start
+
+**Use the `address-pr-comments` skill to automatically resolve review feedback.**
+
+The skill handles the complete workflow: identify unresolved threads, implement
+fixes, post individual resolution replies, create comprehensive summary, and
+mirror updates to linked issues—all without asking for confirmation.
+
+**Skill triggers**: "Address PR comments", "Resolve review feedback",
+"Fix Copilot feedback"
+
+---
+
 ## Overview
+
+This page documents the manual workflow for resolving Copilot PR review feedback.
+For automated execution, use the `address-pr-comments` skill (see Quick Start above).
 
 When Copilot provides review feedback on a pull request, implement fixes and
 automatically manage feedback resolution without requiring explicit user prompts

--- a/.github/skills/address-pr-comments/SKILL.md
+++ b/.github/skills/address-pr-comments/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: address-pr-comments
+description: >
+  Address review comments (including Copilot comments) on the active pull
+  request and post resolution updates. Implements Axiom-specific feedback
+  resolution: individual thread replies, comprehensive summary, and linked
+  issue updates—all automatic.
+context: fork
+argument-hint: "Optionally specify a reviewer name or file to focus on"
+---
+
+# Address PR Review Comments
+
+Read the active pull request, identify unresolved review comments and feedback,
+implement the requested changes, post individual resolution replies to each
+thread, create a comprehensive summary, and mirror updates to linked issues.
+
+## When to Use
+
+- A reviewer has left comments or change requests on the active PR
+- You need to systematically work through all open review threads
+- You want to respond to or implement reviewer feedback
+- You've fixed Copilot feedback and need to post resolutions
+
+## Procedure
+
+### 1. Read the Active PR
+
+Call `github-pull-request_currentActivePullRequest`.
+
+**Refresh logic**:
+
+- Call once without `refresh` to get cached state
+- Inspect `lastUpdatedAt` field
+- If timestamp is **less than 3 minutes ago**, the PR is changing—call again with `refresh: true`
+- If older than 3 minutes, proceed with cached data
+
+### 2. Identify Unresolved Comments
+
+From the result, collect feedback needing action:
+
+- **`reviewThreads` array**: Inline threads with `id`, `isResolved` flag,
+  `canResolve` flag, `file` path, and nested `comments`. Focus on threads where
+  `isResolved` is `false`.
+- **`timelineComments` array**: General PR comments where `commentType` is `"CHANGES_REQUESTED"` or `"COMMENTED"`
+- **Linked issues**: Extract from PR body (e.g., `Refs #123`, `Fixes #456`) for later issue updates
+
+Group related threads by file to handle efficiently.
+
+### 3. Categorize Feedback by Type
+
+Before implementing, categorize comments to structure your response:
+
+- **🔴 Transaction/Consistency Safety**: Data integrity, audit placement, transaction boundaries
+- **🟡 Performance**: N+1 queries, inefficient patterns, unnecessary operations
+- **🟢 Test Coverage**: Missing or insufficient test coverage
+- **🔵 Code Quality**: Simplification, refactoring, best practices
+- **⚪ Configuration/Linting**: Markdown, YAML, formatting compliance
+
+### 4. Plan Changes
+
+For each unresolved comment:
+
+1. Read it carefully and understand the concern
+2. Identify the file and exact location
+3. Determine the minimal correct fix (not all comments require changes)
+4. Note dependencies between comments (e.g., a rename affecting multiple files)
+5. If unclear or contradictory, plan a reply asking for clarification instead
+
+### 5. Implement Changes
+
+Work through grouped comments file by file:
+
+- Read the relevant file section before editing
+- Apply the requested change
+- Do not refactor code outside the scope of each comment
+- Commit changes with a clear message: `fix: address review feedback on [category]`
+
+### 6. Track Resolutions (Session Memory)
+
+Maintain a list of comment IDs and their resolution status:
+
+```text
+✅ RESOLVED (4)
+├─ 3045230708 - Transaction Safety - [description]
+├─ 3045230751 - Transaction Safety - [description]
+├─ 3045230772 - Performance - [description]
+└─ 3046789012 - Code Quality - [description]
+
+⏳ DEFERRED (1)
+└─ 3045230787 - Test Coverage - [Reason: Requires test DB setup]
+```
+
+### 7. Post Individual Resolution Comments (Automatic)
+
+**DO NOT ask for confirmation.** For each resolved comment, post a reply to that thread:
+
+```bash
+gh pr comment <pr-number> --reply-to <comment-id> --body-file "/path/to/resolution.md"
+```
+
+#### Resolution Comment Template by Type
+
+### Transaction Safety
+
+```markdown
+✅ **RESOLVED**: [Issue type - e.g., Audit write before UPDATE]
+
+**Problem**: [Original concern]
+
+**Solution**: Reordered operations to ensure [atomic behavior/consistency]
+- Database operation executes first
+- Audit/logging only occurs if operation succeeds
+- Prevents invalid audit records on failure
+
+**Validation**: All tests pass, no functional changes to behavior
+```
+
+### Performance
+
+```markdown
+✅ **RESOLVED**: [Issue type - e.g., N+1 query pattern]
+
+**Problem**: [Original performance concern]
+
+**Solution**: [Specific optimization applied]
+- Before: [Old pattern with impact]
+- After: [New pattern with benefit]
+- Impact: [Measurable improvement or reasoning]
+
+**Validation**: Local performance verified, existing tests pass
+```
+
+### Test Coverage
+
+```markdown
+✅ **RESOLVED**: [Test coverage for behavior]
+
+**Added/Updated Tests**: [Which test functions cover this]
+
+**Scenarios Covered**:
+- [Happy path test]
+- [Error/edge case test]
+- [Regression test if applicable]
+
+**Validation**: `go test ./...` passes with full coverage on affected modules
+```
+
+### Code Quality
+
+```markdown
+✅ **RESOLVED**: [Simplification/refactoring]
+
+**Change**: [What was simplified or improved]
+
+**Benefit**: [Readability, maintainability, or performance improvement]
+
+**Validation**: Existing tests pass, behavior unchanged
+```
+
+### Configuration/Linting
+
+```markdown
+✅ **RESOLVED**: [Config/lint issue]
+
+**Change**: [What was updated or fixed]
+
+**Validation**: `make docs-check`, linters pass
+```
+
+Use the safe comment helper if available to verify rendered body before posting:
+
+```bash
+pwsh ./scripts/post-gh-comment-safe.ps1 `
+  -Repo "techie2000/axiom" `
+  -TargetType pr `
+  -PrNumber <pr-number> `
+  -ReplyToId <comment-id> `
+  -BodyFile "path/to/resolution.md"
+```
+
+### 8. Push and Verify (Automatic)
+
+After all changes are committed:
+
+1. Push to the PR branch: `git push origin <branch>`
+2. Verify all replies were posted to threads
+3. Collect any deferred items (tests needing infrastructure, follow-ups, etc.)
+
+### 9. Create Comprehensive Summary (Automatic)
+
+**DO NOT ask for confirmation.** Post a summary comment on the main PR:
+
+```bash
+gh pr comment <pr-number> --body-file "/path/to/summary.md"
+```
+
+#### Summary Template
+
+```markdown
+## Copilot Review Feedback: [X] Issues Resolved ✅
+
+All substantive feedback has been addressed. Below is a categorized breakdown.
+
+### Summary by Category
+
+| Category | Count | Status | Notes |
+|----------|-------|--------|-------|
+| Transaction Safety | X | ✅ | [Specific items] |
+| Performance | X | ✅ | [Specific items] |
+| Test Coverage | X | ⏳ | [If deferred, note follow-up plan] |
+| Code Quality | X | ✅ | [Specific items] |
+
+### Detailed Resolutions
+
+#### 🔴 Transaction Safety (X resolved)
+- **[Issue 1]**: [Resolution summary—what changed and why]
+- **[Issue 2]**: [Resolution summary]
+
+#### 🟡 Performance (X resolved)
+- **[Issue 1]**: [Resolution summary]
+- **[Issue 2]**: [Resolution summary]
+
+#### 🟢 Test Coverage (X resolved)
+- **[Issue 1]**: [Resolution summary]
+
+### Validation Checklist
+
+- ✅ All existing tests pass: `go test ./...` or `npm test`
+- ✅ Code compiles without errors
+- ✅ [CI checks status] running with fixes
+- ✅ No functional behavior changes (fixes improve safety/performance/coverage)
+
+### Non-Applicable Comments
+
+- **[Comment type]**: N/A - [Reason, e.g., "Files removed in earlier cleanup"]
+
+### Follow-Up Items
+
+If any feedback is deferred:
+- **[Issue type]**: Deferred to [future PR/phase]
+  - Reason: [Why it's deferred]
+  - What's needed: [Infrastructure, dependencies, etc.]
+
+---
+
+**The PR is ready for review** with all substantive feedback addressed. 🚀
+```
+
+Verify the rendered body immediately:
+
+```bash
+gh pr view <pr-number> --repo techie2000/axiom --comments
+```
+
+### 10. Mirror Updates to Linked Issues (Automatic)
+
+**DO NOT ask for confirmation.** For each linked issue (extracted from PR body):
+
+```bash
+gh issue comment <issue-number> --repo techie2000/axiom --body "..."
+```
+
+#### Issue Update Template
+
+```markdown
+**Implementation Status**: ✅ Feedback Addressed
+
+- PR: [#<pr-number>](https://github.com/techie2000/axiom/pull/<pr-number>)
+- Branch: `<branch-name>`
+- Validation: All tests passing, CI checks complete
+
+**What Changed**:
+- [Brief 1-2 sentence summary of implementation]
+- [Performance or safety improvements made]
+
+**For Testing**: See PR #<pr-number> for detailed changes and validation steps.
+
+**Next Steps**: Awaiting final review before merge.
+```
+
+Verify the issue comment was posted:
+
+```bash
+gh issue view <issue-number> --repo techie2000/axiom --comments
+```
+
+---
+
+## Best Practices
+
+1. **Timing**:
+   - Post individual resolutions **immediately after pushing each fix**
+   - Post comprehensive summary **after all fixes are pushed and CI has started**
+   - Do not merge until all threads are resolved
+
+2. **Clarity**:
+   - Reference specific line numbers or commit SHAs
+   - Explain the "why" not just the "what"
+   - Link related issues or ADRs if applicable
+
+3. **Consistency**:
+   - Use same terminology as the original feedback when summarizing
+   - Group related fixes in summary (e.g., all transaction safety together)
+   - Keep resolution comments concise (1-3 bullet points per issue)
+
+4. **Validation**:
+   - Always verify fixes locally before posting resolution comments
+   - Run relevant test suites: `go test ./... -cover`, `npm test`
+   - Wait for initial CI checks before posting comprehensive summary
+
+---
+
+## See Also
+
+- `copilot-pr-feedback-resolution.instructions.md` - Detailed workflow
+- `copilot-pr-comment-tracking.instructions.md` - Comment ID tracking patterns
+- `github-comment-formatting.instructions.md` - Comment formatting rules

--- a/.github/skills/address-pr-comments/SKILL.md
+++ b/.github/skills/address-pr-comments/SKILL.md
@@ -168,9 +168,10 @@ gh pr comment <pr-number> --reply-to <comment-id> --body-file "/path/to/resoluti
 **Validation**: `make docs-check`, linters pass
 ```
 
-Use the safe comment helper if available to verify rendered body before posting:
+Use the safe comment helper if available to verify rendered body before posting.
+For Bash shells, use the `gh pr comment --reply-to` command shown above.
 
-```bash
+```powershell
 pwsh ./scripts/post-gh-comment-safe.ps1 `
   -Repo "techie2000/axiom" `
   -TargetType pr `

--- a/.github/skills/create-pull-request/SKILL.md
+++ b/.github/skills/create-pull-request/SKILL.md
@@ -225,7 +225,7 @@ gh issue comment <issue-number> --repo techie2000/axiom --body "..."
 
 Issue update body template:
 
-```bash
+```markdown
 **PR Status**: Implementation started
 
 - PR: [#<pr-number>](https://github.com/techie2000/axiom/pull/<pr-number>)

--- a/.github/skills/create-pull-request/SKILL.md
+++ b/.github/skills/create-pull-request/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: create-pull-request
+description: >
+  Create a GitHub Pull Request with automatic label application, reviewer
+  assignment, and verification checklist. Encodes Axiom-specific PR hygiene:
+  three-namespace labels, verification checklists, issue linking, and reviewer
+  defaults.
+context: fork
+argument-hint: >
+  Optionally specify a title, base branch, or whether to create as a draft
+---
+
+# Create a GitHub Pull Request
+
+Prepare PR metadata, create the pull request, apply project labels and reviewer
+defaults, and post verification checklist without asking for confirmation.
+
+## When to Use
+
+- The user wants to open a PR for their current or a specified branch
+- The user has finished a feature or fix and wants to submit it for review
+- The user wants to create a draft PR to share work in progress
+- The user asks to "open a PR", "create a pull request", or "submit for
+  review"
+
+## Procedure
+
+### 1. Gather Information
+
+Determine the required parameters before calling the tool:
+
+- **Head branch**: If the user has not specified a branch, use workspace or git
+  context to find the current branch name. Do not use `owner:branch`
+  format—pass just the branch name (e.g., `my-feature`).
+- **Base branch**: If the user has not specified a base branch, omit it and let
+  the tool use the repository's default branch.
+- **Title**: If the user has not provided a title, derive one from the branch
+  name, recent commits, or the user's description of their work.
+- **Body**: If the user has not provided a description, prepare a concise
+  summary of what changed and why.
+- **Draft**: Ask or infer whether the PR should be a draft. Default to
+  non-draft unless the user indicates the work is not ready for review.
+
+### 2. Check for Uncommitted or Unpushed Changes
+
+Before creating the PR, inspect the working tree state.
+
+1. **Check for uncommitted changes**: Use git or VS Code SCM to determine
+   whether there are staged or unstaged file changes. If yes, ask the user to
+   commit them or clarify if there are already commits on the branch ahead of
+   base.
+2. **Check for unpushed commits**: Determine whether the local branch has
+   commits not pushed to remote. If yes, push before calling the tool.
+3. **Confirm the branch is on the remote**: The create tool requires the head
+   branch to be present on the remote.
+
+If all changes are already committed and pushed, proceed to the next step.
+
+### 3. Prepare PR Details
+
+Write a good title and description if the user has not provided them:
+
+**Title**: Use imperative mood, keep it under 72 characters, describe what the
+PR does (e.g., `Add retry logic for failed API requests`).
+
+**Body**: Include:
+
+- A short summary of what changed and why
+- Any relevant issue references (e.g., `Fixes #123`, `Refs #123`)
+- Notable implementation decisions if useful for the reviewer
+
+### 4. Create the PR
+
+Use the `github-pull-request_create_pull_request` tool with the gathered
+parameters. Capture the PR URL and number from the result.
+
+### 5. Apply Project Labels (Automatic)
+
+**DO NOT ask for confirmation.** Apply labels based on changed files and PR
+context:
+
+#### Label Taxonomy
+
+Three-namespace system:
+
+1. **Category** (optional, max one): Add only if it conveys information not
+   already implied by Area
+   - `bug` — defect fix
+   - `enhancement` — new feature or capability
+   - `security` — security issue or fix
+   - `performance` — performance improvement
+   - `question` — unclear or needs clarification
+
+2. **Area** (required, exactly one): Inferred from changed files or let CI
+   auto-detect
+   - `area:backend` — Go backend code changes
+   - `area:frontend` — React/Next.js frontend changes
+   - `area:database` — migrations, schema, or DB-related
+   - `area:docs` — documentation and guides
+   - `area:infra` — Docker, Docker Compose, infrastructure
+   - `area:ci` — GitHub Actions workflows
+   - `area:lei` — LEI-specific features
+   - `area:dependencies` — dependency updates
+
+3. **Type** (optional secondary, one or two):
+   - `type:tests` — test additions or modifications
+   - `type:refactor` — code restructuring without behavior change
+   - `type:chore` — maintenance, tooling
+
+#### Special Labels
+
+- `automated` — mark AI-created items
+- `no-issue-needed` — for PRs with no backing issue
+- `hotfix` — for replacement promotion branches (e.g.,
+  `fix/sync-dev-from-main-*` targeting `dev` without correct source). Combine
+  with `no-issue-needed` **immediately at PR creation** before CI checks run.
+
+#### Application Logic
+
+1. Determine Area from changed files:
+   - `backend/**/*.go` → `area:backend`
+   - `frontend/**/*.{ts,tsx,js,jsx}` → `area:frontend`
+   - `backend/migrations/**` → `area:database`
+   - `docs/**/*.md` → `area:docs`
+   - `docker/**` or `docker-compose*.yml` → `area:infra`
+   - `.github/workflows/**` → `area:ci`
+   - Files containing `lei` or `LEI` → `area:lei`
+   - `go.mod`, `package.json`, `package-lock.json`, `go.sum` →
+     `area:dependencies`
+
+2. Infer Category from PR context:
+   - PR title or body contains "security" or "vulnerability" → add `security`
+   - PR title or body contains "performance" or "optimize" → add `performance`
+   - PR title or body contains "bug" or "fix" → add `bug`
+   - PR title or body contains "feature" or "add" → add `enhancement`
+
+3. Infer Type from changed files:
+   - `*_test.go` or `*.test.ts` or `*.test.tsx` → add `type:tests`
+   - Only non-functional file changes (config, comments, formatting) →
+     add `type:chore`
+
+4. Add `automated` if this skill created the PR.
+
+5. Avoid duplicate semantics: Do not add `documentation` when `area:docs` is present.
+
+#### Label Application
+
+```bash
+gh pr edit <pr-number> --repo techie2000/axiom --add-label "label1,label2,label3"
+```
+
+### 6. Request Reviewer (Automatic)
+
+**DO NOT ask for confirmation.** Request the default reviewer:
+
+```bash
+gh pr edit <pr-number> --repo techie2000/axiom --add-reviewer copilot-pull-request-reviewer
+```
+
+If the reviewer handle is unavailable, note it but proceed.
+
+### 7. Post Verification Checklist (Automatic)
+
+**DO NOT ask for confirmation.** Post a concise checklist comment relevant to the changed files.
+
+Examples by area:
+
+**Backend (`area:backend`)**:
+
+```text
+✅ Verification Checklist
+
+- [ ] Tests added/updated (`go test ./... -v`)
+- [ ] Build passes (`make build`)
+- [ ] No SQL injection or security issues
+- [ ] Transaction safety verified
+- [ ] Error handling complete
+```
+
+**Frontend (`area:frontend`)**:
+
+```text
+✅ Verification Checklist
+
+- [ ] UI renders correctly in light/dark mode
+- [ ] i18n keys added (no hardcoded text)
+- [ ] Tested in Chrome, Firefox, Safari
+- [ ] Mobile responsive verified
+- [ ] Accessibility (ARIA, keyboard navigation) checked
+```
+
+**Database (`area:database`)**:
+
+```text
+✅ Verification Checklist
+
+- [ ] `.up.sql` migration present
+- [ ] `.down.sql` rollback migration present
+- [ ] Naming follows `XXXXXX_description` pattern
+- [ ] Tested locally with `make migrate-up` / `make migrate-down`
+```
+
+**Infrastructure (`area:infra`)**:
+
+```text
+✅ Verification Checklist
+
+- [ ] Docker image builds: `docker build -f Dockerfile.backend`
+- [ ] docker-compose starts without errors
+- [ ] Health checks configured
+- [ ] Environment variables documented
+```
+
+Use `gh pr comment <pr-number> --body "..."` or the safe comment helper if available.
+
+### 8. Post to Linked Issues (Automatic)
+
+If the PR body references linked issues (e.g., `Refs #123`, `Fixes #456`):
+
+For each linked issue that is confirmed to be an **issue** (not a PR):
+
+```bash
+gh issue comment <issue-number> --repo techie2000/axiom --body "..."
+```
+
+Issue update body template:
+
+```bash
+**PR Status**: Implementation started
+
+- PR: [#<pr-number>](https://github.com/techie2000/axiom/pull/<pr-number>)
+- Branch: `<branch-name>`
+- Validation: Pending
+
+**For Testing**: See PR description for test commands and validation steps.
+```
+
+---
+
+## Best Practices
+
+1. **Imperative title**: "Add X", "Fix Y", "Update Z"
+2. **Link issues early**: Use `Fixes #123` or `Refs #123` in the body
+3. **Explain the why**: Not just what changed, but why
+4. **No asking**: Label, review, and checklist are automatic
+
+---
+
+## See Also
+
+- `copilot-instructions.md` - PR finalization defaults
+- `code-review-generic.instructions.md` - Review standards

--- a/.github/skills/github-issues/SKILL.md
+++ b/.github/skills/github-issues/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: github-issues
 description: 'Create, update, and manage GitHub issues using MCP tools. Use this skill when users want to create bug reports, feature requests, or task issues, update existing issues, add labels/assignees/milestones, or manage issue workflows. Triggers on requests like "create an issue", "file a bug", "request a feature", "update issue X", or any GitHub issue management task.'
+context: fork
 ---
 
 # GitHub Issues


### PR DESCRIPTION
## Overview

Add three project-specific skills with \context: fork\ to isolate multi-step tool execution and improve context quality for follow-up responses.

## Changes

### 1. github-issues Skill
- Added \context: fork\ to isolate MCP tool calls and reference material
- Keeps main chat focused and responses higher quality

### 2. create-pull-request Skill
- Automatic label taxonomy application (Category/Area/Type)
- Default reviewer assignment (\copilot-pull-request-reviewer\)
- Context-aware verification checklists by area
- Linked issue update mirroring
- No confirmation prompts—automatic execution

### 3. address-pr-comments Skill  
- Identifies and categorizes unresolved review feedback
- Posts individual resolution replies to comment threads
- Creates comprehensive summary comments
- Mirrors updates to linked issues
- Isolates multi-step operations in fork context

### 4. Updated Instructions
- \copilot-instructions.md\: Added reference to \create-pull-request\ skill for PR finalization
- \copilot-pr-feedback-resolution.instructions.md\: Added quick-start directing to \ddress-pr-comments\ skill
- \copilot-pr-comment-tracking.instructions.md\: Added note that tracking patterns are used internally by the skill

## Technical Details

All three skills use \context: fork\ from the latest VS Code release, which requires \github.copilot.chat.skillTool.enabled\ setting. This isolates auxiliary tool calls and context loading, improving response quality for follow-up prompts.

Fixes #AXIOM-WORKFLOWS