### PR TITLE
feat(ci): add hotfix backport gate workflow and update agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -669,6 +669,33 @@ If manually applying labels (not using the skill), follow this taxonomy:
 - Avoid duplicate semantics: do not add `documentation` when `area:docs` is present.
 - Category labels are only needed when orthogonal to Area (e.g., `area:backend` change that is also `security` should add `security`).
 
+### Hotfix Backport Gate (REQUIRED)
+
+When a PR merges directly into `dev`, `uat`, or `prod` using `hotfix` or `emergency` labels,
+the agent must ensure those changes are not lost in later promotions.
+
+Workflow:
+
+1. Identify whether the merged PR introduced changes that are not already on `main`:
+   - `gh pr view <pr> --repo <owner>/<repo> --json files,commits`
+   - `git fetch origin --prune`
+   - `git cherry -v origin/main origin/<target-env-branch>`
+2. For each substantive change missing from `main`, create a backport PR targeting `main`.
+   - Prefer cherry-picking focused fix commits.
+   - Do **not** blindly cherry-pick merge commits; extract intentional edits instead.
+3. Cross-link the PRs:
+   - In the env hotfix PR, post `Backport PR: #<id>`.
+   - In the backport PR, post `Backports hotfix PR: #<id>`.
+4. Treat the hotfix as incomplete until either:
+   - the backport PR to `main` exists, or
+   - a documented waiver explains why backport is not required.
+
+Rules:
+
+- Apply this gate to direct env hotfixes for `dev`, `uat`, and `prod`.
+- Backport only meaningful fixes. Avoid noisy backports for pure promotion-sync merges.
+- If a fix already exists on `main` with equivalent patch content, do not duplicate it.
+
 ### Required Check Context Fallback (REQUIRED)
 
 If a required check shows `Expected — Waiting for status to be reported` while the corresponding

--- a/.github/instructions/pr-merge-cleanup.instructions.md
+++ b/.github/instructions/pr-merge-cleanup.instructions.md
@@ -33,7 +33,27 @@ gh api repos/techie2000/axiom/pulls/{PR_NUMBER} --jq '{number, state, merged, ti
 # Should show: "merged": true
 ```
 
-### Step 3: Delete Local Branches
+### Step 3: Run Hotfix Backport Gate (for env direct merges)
+
+If the merged PR targeted `dev`, `uat`, or `prod` via `hotfix`/`emergency` labels,
+check whether it introduced substantive changes not present on `main`.
+
+```bash
+# Inspect merged PR metadata and changed files
+gh pr view {PR_NUMBER} --repo techie2000/axiom --json baseRefName,headRefName,labels,files,commits
+
+# Refresh refs and compare branch patch delta versus main
+git fetch origin --prune
+git cherry -v origin/main origin/{env-branch}
+```
+
+If meaningful fixes are missing on `main`:
+
+- Create a backport branch from `main`.
+- Cherry-pick focused fix commits (avoid blind merge-commit cherry-picks).
+- Open a PR to `main` and cross-link both PRs.
+
+### Step 4: Delete Local Branches
 
 Once merge is confirmed:
 
@@ -48,7 +68,7 @@ git branch -d {branch-name}
 git branch -D {branch-name}
 ```
 
-### Step 4: Remove Associated Worktrees (if any)
+### Step 5: Remove Associated Worktrees (if any)
 
 ```bash
 # List worktrees
@@ -64,7 +84,7 @@ git branch -d {branch-name}
 git branch -D {branch-name}
 ```
 
-### Step 5: Prune Remote Refs
+### Step 6: Prune Remote Refs
 
 ```bash
 git fetch origin --prune
@@ -130,6 +150,7 @@ git fetch origin --prune
 
 After cleanup:
 
+- [ ] For env hotfix merges, confirm a backport PR to `main` exists or a waiver is documented
 - [ ] Check remaining branches: `git branch -v`
 - [ ] Verify no orphaned worktree directories in `worktrees/`
 - [ ] Confirm no stale remote refs remain: `git remote prune origin --dry-run`
@@ -144,3 +165,4 @@ After cleanup:
     intentionally discarding local-only commits
 - **Single source of truth**: GitHub is authoritative; local branches are ephemeral
 - **Batch deletions** when multiple PRs merge (more efficient)
+- **Do not skip backports** for direct env hotfixes with real fixes; otherwise later promotion can overwrite them

--- a/.github/workflows/check-hotfix-backport.yml
+++ b/.github/workflows/check-hotfix-backport.yml
@@ -1,0 +1,80 @@
+name: Check Hotfix Backport
+
+on:
+  pull_request_target:
+    branches:
+      - dev
+      - uat
+      - prod
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-backport:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require backport reference or waiver for hotfix/emergency env PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request
+            const base = pr.base.ref
+            const labels = (pr.labels || []).map((l) =>
+              (typeof l === 'string' ? l : l.name).toLowerCase()
+            )
+            const title = (pr.title || '').toLowerCase()
+            const body = pr.body || ''
+
+            const isEnvTarget =
+              base === 'dev' || base === 'uat' || base === 'prod'
+
+            const isHotfix =
+              labels.includes('hotfix') ||
+              labels.includes('emergency') ||
+              title.startsWith('hotfix:') ||
+              title.startsWith('emergency:')
+
+            if (!isEnvTarget || !isHotfix) {
+              core.info('Not a hotfix/emergency PR targeting an env branch; skipping backport check.')
+              return
+            }
+
+            // Check for a backport PR cross-reference in the body.
+            const hasBackportRef = /backport\s+pr\s*[:#]?\s*#?\d+/i.test(body) ||
+              /backports?\s+hotfix\s+pr\s*[:#]?\s*#?\d+/i.test(body) ||
+              /\bbackport\b.*#\d+/i.test(body) ||
+              /#\d+.*\bbackport\b/i.test(body)
+
+            // Check for an explicit waiver block.
+            const hasWaiver =
+              /##\s*backport\s+waiver/i.test(body) ||
+              /backport\s+not\s+required/i.test(body) ||
+              /no\s+backport\s+needed/i.test(body)
+
+            if (hasBackportRef) {
+              core.info('Backport PR reference found in PR body; requirement satisfied.')
+              return
+            }
+
+            if (hasWaiver) {
+              core.info('Backport waiver section found in PR body; requirement satisfied.')
+              return
+            }
+
+            core.setFailed(
+              `Hotfix backport gate: this ${base === 'uat' ? 'uat' : base === 'prod' ? 'prod' : 'dev'} ` +
+              `hotfix/emergency PR must include one of:\n` +
+              `  1. A backport PR reference — e.g., "Backport PR: #<number>" in the description.\n` +
+              `  2. A waiver section — a "## Backport Waiver" heading or "Backport not required: <reason>".\n\n` +
+              `Rationale: changes merged directly into env branches can be overwritten by later ` +
+              `promotions unless they are also applied to main.`
+            )


### PR DESCRIPTION
## Summary

Adds a mandatory CI gate that blocks hotfix/emergency PRs targeting `dev`, `uat`, or `prod`
unless the PR body contains either a backport reference or an explicit waiver.

## Why

When PRs merge directly into env branches via the `hotfix` or `emergency` override path,
their changes can be silently overwritten by the next normal promotion from `main`.
PRs #483 (dev hotfix) and #488 (uat hotfix) both illustrate this gap — several
substantive file changes are not yet on `main`.

## What changed

- `.github/workflows/check-hotfix-backport.yml` — new required CI check
  - triggers on `pull_request_target` for `dev`, `uat`, `prod` branches
  - only activates when `hotfix` or `emergency` label/title prefix is present
  - passes if the PR body contains a backport PR cross-reference, e.g. `Backport PR: #123`
  - passes if the PR body contains a waiver, e.g. `## Backport Waiver` or `Backport not required:`
  - fails with an actionable message otherwise
- `.github/copilot-instructions.md` — added **Hotfix Backport Gate (REQUIRED)** section under
  PR Finalization Default with explicit workflow steps and rules
- `.github/instructions/pr-merge-cleanup.instructions.md` — added **Step 3: Run Hotfix Backport Gate**
  to the cleanup workflow, backport checklist item, and a notes entry

## Satisfying the gate

In a hotfix PR description, add one of:

```text
Backport PR: #<number>
```

or

```markdown
## Backport Waiver
Backport not required: these changes are already present on main via PR #<number>.
```

## Validation

- Markdown lint: `make docs-check` — 0 errors
- YAML syntax: validated
