### PR TITLE
fix: avoid Level 1 self-reference FK failures during full sync

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,14 +6,6 @@
       "approve": true,
       "matchCommandLine": true
     },
-    "/^& \\./scripts/run-main-compose\\.ps1 build backend$/": {
-      "approve": true,
-      "matchCommandLine": true
-    },
-    "/^& \\./scripts/run-main-compose\\.ps1 ps$/": {
-      "approve": true,
-      "matchCommandLine": true
-    },
     "/^docker rm -f axiom-main-frontend; docker volume rm axiom-main_frontend_node_modules_main axiom-main_frontend_next_main; pwsh -NoProfile -ExecutionPolicy Bypass -File \\./scripts/run-main-compose\\.ps1 up -d frontend$/": {
       "approve": true,
       "matchCommandLine": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,14 @@
       "approve": true,
       "matchCommandLine": true
     },
+    "/^& \\./scripts/run-main-compose\\.ps1 build backend$/": {
+      "approve": true,
+      "matchCommandLine": true
+    },
+    "/^& \\./scripts/run-main-compose\\.ps1 ps$/": {
+      "approve": true,
+      "matchCommandLine": true
+    },
     "/^docker rm -f axiom-main-frontend; docker volume rm axiom-main_frontend_node_modules_main axiom-main_frontend_next_main; pwsh -NoProfile -ExecutionPolicy Bypass -File \\./scripts/run-main-compose\\.ps1 up -d frontend$/": {
       "approve": true,
       "matchCommandLine": true

--- a/backend/internal/repository/lei_repository.go
+++ b/backend/internal/repository/lei_repository.go
@@ -33,6 +33,7 @@ type LEIRepository interface {
 	UpdateLEIRecord(record *domain.LEIRecord) error
 	UpsertLEIRecord(record *domain.LEIRecord) (bool, error)              // Returns true if updated, false if created
 	BatchUpsertLEIRecords(records []*domain.LEIRecord) (int, int, error) // Returns (created, updated, error)
+	BatchUpdateLEILinkReferences(records []*domain.LEIRecord) (int, error)
 	DeleteLEI(id string) error
 
 	// Source File operations
@@ -1049,7 +1050,7 @@ func (r *leiRepository) BatchUpsertLEIRecords(records []*domain.LEIRecord) (crea
 		}
 
 		valueStrings := make([]string, 0, len(plans))
-		valueArgs := make([]interface{}, 0, len(plans)*44)
+		valueArgs := make([]interface{}, 0, len(plans)*41)
 
 		// Generate all values in Go, use placeholders for everything
 		now := time.Now()
@@ -1057,8 +1058,9 @@ func (r *leiRepository) BatchUpsertLEIRecords(records []*domain.LEIRecord) (crea
 
 		for _, plan := range plans {
 			record := plan.record
-			// Use placeholders for ALL fields (43 total)
-			valueStrings = append(valueStrings, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+			// Self-referential link fields are reconciled after the full file load so
+			// forward references do not fail mid-import.
+			valueStrings = append(valueStrings, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 
 			// Generate ID and timestamps in Go
 			insertID := uuid.New()
@@ -1097,12 +1099,10 @@ func (r *leiRepository) BatchUpsertLEIRecords(records []*domain.LEIRecord) (crea
 				record.EntityStatus,                        // entity_status
 				record.LegalJurisdiction,                   // legal_jurisdiction
 				record.RegistrationStatus,                  // registration_status
-				nullableLEICode(record.SuccessorLEI),       // successor_lei
 				nullableCode(record.ValidationAuthority),   // validation_authority
 				record.InitialRegistrationDate,             // initial_registration_date
 				record.LastUpdateDate,                      // last_update_date
 				record.NextRenewalDate,                     // next_renewal_date
-				nullableCode(record.ManagingLOU),           // managing_lou
 				record.ValidationSources,                   // validation_sources
 				record.SourceFileID,                        // source_file_id
 				now,                                        // created_at
@@ -1114,138 +1114,7 @@ func (r *leiRepository) BatchUpsertLEIRecords(records []*domain.LEIRecord) (crea
 		}
 
 		// Execute upsert with RETURNING to get IDs
-		stmt := fmt.Sprintf(`
-			INSERT INTO lei_raw.lei_records (
-				id, lei, legal_name, transliterated_legal_name, other_names,
-				legal_address_line_1, legal_address_line_2, legal_address_line_3, legal_address_line_4,
-				legal_address_city, legal_address_region, legal_address_country, legal_address_postal_code,
-				hq_address_line_1, hq_address_line_2, hq_address_line_3, hq_address_line_4,
-				hq_address_city, hq_address_region, hq_address_country, hq_address_postal_code,
-				registration_authority, registration_authority_id, registration_number,
-				entity_category, entity_sub_category, entity_legal_form,
-				entity_status, legal_jurisdiction, registration_status,
-				successor_lei, validation_authority,
-				initial_registration_date, last_update_date, next_renewal_date,
-				managing_lou, validation_sources,
-				source_file_id,
-				created_at, updated_at, created_by, updated_by, changed_fields
-			) VALUES %s
-			ON CONFLICT (lei) DO UPDATE SET
-				legal_name = EXCLUDED.legal_name,
-				transliterated_legal_name = EXCLUDED.transliterated_legal_name,
-				other_names = EXCLUDED.other_names,
-				entity_status = EXCLUDED.entity_status,
-				legal_address_line_1 = EXCLUDED.legal_address_line_1,
-				legal_address_line_2 = EXCLUDED.legal_address_line_2,
-				legal_address_line_3 = EXCLUDED.legal_address_line_3,
-				legal_address_line_4 = EXCLUDED.legal_address_line_4,
-				legal_address_city = EXCLUDED.legal_address_city,
-				legal_address_region = EXCLUDED.legal_address_region,
-				legal_address_country = EXCLUDED.legal_address_country,
-				legal_address_postal_code = EXCLUDED.legal_address_postal_code,
-				hq_address_line_1 = EXCLUDED.hq_address_line_1,
-				hq_address_line_2 = EXCLUDED.hq_address_line_2,
-				hq_address_line_3 = EXCLUDED.hq_address_line_3,
-				hq_address_line_4 = EXCLUDED.hq_address_line_4,
-				hq_address_city = EXCLUDED.hq_address_city,
-				hq_address_region = EXCLUDED.hq_address_region,
-				hq_address_country = EXCLUDED.hq_address_country,
-				hq_address_postal_code = EXCLUDED.hq_address_postal_code,
-				registration_authority = EXCLUDED.registration_authority,
-				registration_authority_id = EXCLUDED.registration_authority_id,
-				registration_number = EXCLUDED.registration_number,
-				entity_category = EXCLUDED.entity_category,
-				entity_sub_category = EXCLUDED.entity_sub_category,
-				entity_legal_form = EXCLUDED.entity_legal_form,
-				legal_jurisdiction = EXCLUDED.legal_jurisdiction,
-				registration_status = EXCLUDED.registration_status,
-				successor_lei = EXCLUDED.successor_lei,
-				validation_authority = EXCLUDED.validation_authority,
-				initial_registration_date = EXCLUDED.initial_registration_date,
-				last_update_date = EXCLUDED.last_update_date,
-				next_renewal_date = EXCLUDED.next_renewal_date,
-				managing_lou = EXCLUDED.managing_lou,
-				validation_sources = EXCLUDED.validation_sources,
-				source_file_id = EXCLUDED.source_file_id,
-				updated_at = NOW(),
-				updated_by = 'system'
-			WHERE
-			(
-				lei_raw.lei_records.legal_name,
-				lei_raw.lei_records.transliterated_legal_name,
-				lei_raw.lei_records.other_names,
-				lei_raw.lei_records.entity_status,
-				lei_raw.lei_records.legal_address_line_1,
-				lei_raw.lei_records.legal_address_line_2,
-				lei_raw.lei_records.legal_address_line_3,
-				lei_raw.lei_records.legal_address_line_4,
-				lei_raw.lei_records.legal_address_city,
-				lei_raw.lei_records.legal_address_region,
-				lei_raw.lei_records.legal_address_country,
-				lei_raw.lei_records.legal_address_postal_code,
-				lei_raw.lei_records.hq_address_line_1,
-				lei_raw.lei_records.hq_address_line_2,
-				lei_raw.lei_records.hq_address_line_3,
-				lei_raw.lei_records.hq_address_line_4,
-				lei_raw.lei_records.hq_address_city,
-				lei_raw.lei_records.hq_address_region,
-				lei_raw.lei_records.hq_address_country,
-				lei_raw.lei_records.hq_address_postal_code,
-				lei_raw.lei_records.registration_authority,
-				lei_raw.lei_records.registration_authority_id,
-				lei_raw.lei_records.registration_number,
-				lei_raw.lei_records.entity_category,
-				lei_raw.lei_records.entity_sub_category,
-				lei_raw.lei_records.entity_legal_form,
-				lei_raw.lei_records.legal_jurisdiction,
-				lei_raw.lei_records.registration_status,
-				lei_raw.lei_records.successor_lei,
-				lei_raw.lei_records.validation_authority,
-				lei_raw.lei_records.initial_registration_date,
-				lei_raw.lei_records.last_update_date,
-				lei_raw.lei_records.next_renewal_date,
-				lei_raw.lei_records.managing_lou,
-				lei_raw.lei_records.validation_sources,
-				lei_raw.lei_records.source_file_id
-			) IS DISTINCT FROM (
-				EXCLUDED.legal_name,
-				EXCLUDED.transliterated_legal_name,
-				EXCLUDED.other_names,
-				EXCLUDED.entity_status,
-				EXCLUDED.legal_address_line_1,
-				EXCLUDED.legal_address_line_2,
-				EXCLUDED.legal_address_line_3,
-				EXCLUDED.legal_address_line_4,
-				EXCLUDED.legal_address_city,
-				EXCLUDED.legal_address_region,
-				EXCLUDED.legal_address_country,
-				EXCLUDED.legal_address_postal_code,
-				EXCLUDED.hq_address_line_1,
-				EXCLUDED.hq_address_line_2,
-				EXCLUDED.hq_address_line_3,
-				EXCLUDED.hq_address_line_4,
-				EXCLUDED.hq_address_city,
-				EXCLUDED.hq_address_region,
-				EXCLUDED.hq_address_country,
-				EXCLUDED.hq_address_postal_code,
-				EXCLUDED.registration_authority,
-				EXCLUDED.registration_authority_id,
-				EXCLUDED.registration_number,
-				EXCLUDED.entity_category,
-				EXCLUDED.entity_sub_category,
-				EXCLUDED.entity_legal_form,
-				EXCLUDED.legal_jurisdiction,
-				EXCLUDED.registration_status,
-				EXCLUDED.successor_lei,
-				EXCLUDED.validation_authority,
-				EXCLUDED.initial_registration_date,
-				EXCLUDED.last_update_date,
-				EXCLUDED.next_renewal_date,
-				EXCLUDED.managing_lou,
-				EXCLUDED.validation_sources,
-				EXCLUDED.source_file_id
-			)
-	`, strings.Join(valueStrings, ","))
+		stmt := buildLEIRecordBatchUpsertSQL(strings.Join(valueStrings, ","))
 
 		// Execute batch upsert using Exec (better placeholder handling than Raw)
 		result := tx.Exec(stmt, valueArgs...)
@@ -1346,6 +1215,198 @@ func (r *leiRepository) BatchUpsertLEIRecords(records []*domain.LEIRecord) (crea
 		Msg("Batch upsert with full audit trail completed successfully")
 
 	return createdCount, updatedCount, nil
+}
+
+func buildLEIRecordBatchUpsertSQL(values string) string {
+	return fmt.Sprintf(`
+			INSERT INTO lei_raw.lei_records (
+				id, lei, legal_name, transliterated_legal_name, other_names,
+				legal_address_line_1, legal_address_line_2, legal_address_line_3, legal_address_line_4,
+				legal_address_city, legal_address_region, legal_address_country, legal_address_postal_code,
+				hq_address_line_1, hq_address_line_2, hq_address_line_3, hq_address_line_4,
+				hq_address_city, hq_address_region, hq_address_country, hq_address_postal_code,
+				registration_authority, registration_authority_id, registration_number,
+				entity_category, entity_sub_category, entity_legal_form,
+				entity_status, legal_jurisdiction, registration_status,
+				validation_authority,
+				initial_registration_date, last_update_date, next_renewal_date,
+				validation_sources,
+				source_file_id,
+				created_at, updated_at, created_by, updated_by, changed_fields
+			) VALUES %s
+			ON CONFLICT (lei) DO UPDATE SET
+				legal_name = EXCLUDED.legal_name,
+				transliterated_legal_name = EXCLUDED.transliterated_legal_name,
+				other_names = EXCLUDED.other_names,
+				entity_status = EXCLUDED.entity_status,
+				legal_address_line_1 = EXCLUDED.legal_address_line_1,
+				legal_address_line_2 = EXCLUDED.legal_address_line_2,
+				legal_address_line_3 = EXCLUDED.legal_address_line_3,
+				legal_address_line_4 = EXCLUDED.legal_address_line_4,
+				legal_address_city = EXCLUDED.legal_address_city,
+				legal_address_region = EXCLUDED.legal_address_region,
+				legal_address_country = EXCLUDED.legal_address_country,
+				legal_address_postal_code = EXCLUDED.legal_address_postal_code,
+				hq_address_line_1 = EXCLUDED.hq_address_line_1,
+				hq_address_line_2 = EXCLUDED.hq_address_line_2,
+				hq_address_line_3 = EXCLUDED.hq_address_line_3,
+				hq_address_line_4 = EXCLUDED.hq_address_line_4,
+				hq_address_city = EXCLUDED.hq_address_city,
+				hq_address_region = EXCLUDED.hq_address_region,
+				hq_address_country = EXCLUDED.hq_address_country,
+				hq_address_postal_code = EXCLUDED.hq_address_postal_code,
+				registration_authority = EXCLUDED.registration_authority,
+				registration_authority_id = EXCLUDED.registration_authority_id,
+				registration_number = EXCLUDED.registration_number,
+				entity_category = EXCLUDED.entity_category,
+				entity_sub_category = EXCLUDED.entity_sub_category,
+				entity_legal_form = EXCLUDED.entity_legal_form,
+				legal_jurisdiction = EXCLUDED.legal_jurisdiction,
+				registration_status = EXCLUDED.registration_status,
+				validation_authority = EXCLUDED.validation_authority,
+				initial_registration_date = EXCLUDED.initial_registration_date,
+				last_update_date = EXCLUDED.last_update_date,
+				next_renewal_date = EXCLUDED.next_renewal_date,
+				validation_sources = EXCLUDED.validation_sources,
+				source_file_id = EXCLUDED.source_file_id,
+				updated_at = NOW(),
+				updated_by = 'system'
+			WHERE
+			(
+				lei_raw.lei_records.legal_name,
+				lei_raw.lei_records.transliterated_legal_name,
+				lei_raw.lei_records.other_names,
+				lei_raw.lei_records.entity_status,
+				lei_raw.lei_records.legal_address_line_1,
+				lei_raw.lei_records.legal_address_line_2,
+				lei_raw.lei_records.legal_address_line_3,
+				lei_raw.lei_records.legal_address_line_4,
+				lei_raw.lei_records.legal_address_city,
+				lei_raw.lei_records.legal_address_region,
+				lei_raw.lei_records.legal_address_country,
+				lei_raw.lei_records.legal_address_postal_code,
+				lei_raw.lei_records.hq_address_line_1,
+				lei_raw.lei_records.hq_address_line_2,
+				lei_raw.lei_records.hq_address_line_3,
+				lei_raw.lei_records.hq_address_line_4,
+				lei_raw.lei_records.hq_address_city,
+				lei_raw.lei_records.hq_address_region,
+				lei_raw.lei_records.hq_address_country,
+				lei_raw.lei_records.hq_address_postal_code,
+				lei_raw.lei_records.registration_authority,
+				lei_raw.lei_records.registration_authority_id,
+				lei_raw.lei_records.registration_number,
+				lei_raw.lei_records.entity_category,
+				lei_raw.lei_records.entity_sub_category,
+				lei_raw.lei_records.entity_legal_form,
+				lei_raw.lei_records.legal_jurisdiction,
+				lei_raw.lei_records.registration_status,
+				lei_raw.lei_records.validation_authority,
+				lei_raw.lei_records.initial_registration_date,
+				lei_raw.lei_records.last_update_date,
+				lei_raw.lei_records.next_renewal_date,
+				lei_raw.lei_records.validation_sources,
+				lei_raw.lei_records.source_file_id
+			) IS DISTINCT FROM (
+				EXCLUDED.legal_name,
+				EXCLUDED.transliterated_legal_name,
+				EXCLUDED.other_names,
+				EXCLUDED.entity_status,
+				EXCLUDED.legal_address_line_1,
+				EXCLUDED.legal_address_line_2,
+				EXCLUDED.legal_address_line_3,
+				EXCLUDED.legal_address_line_4,
+				EXCLUDED.legal_address_city,
+				EXCLUDED.legal_address_region,
+				EXCLUDED.legal_address_country,
+				EXCLUDED.legal_address_postal_code,
+				EXCLUDED.hq_address_line_1,
+				EXCLUDED.hq_address_line_2,
+				EXCLUDED.hq_address_line_3,
+				EXCLUDED.hq_address_line_4,
+				EXCLUDED.hq_address_city,
+				EXCLUDED.hq_address_region,
+				EXCLUDED.hq_address_country,
+				EXCLUDED.hq_address_postal_code,
+				EXCLUDED.registration_authority,
+				EXCLUDED.registration_authority_id,
+				EXCLUDED.registration_number,
+				EXCLUDED.entity_category,
+				EXCLUDED.entity_sub_category,
+				EXCLUDED.entity_legal_form,
+				EXCLUDED.legal_jurisdiction,
+				EXCLUDED.registration_status,
+				EXCLUDED.validation_authority,
+				EXCLUDED.initial_registration_date,
+				EXCLUDED.last_update_date,
+				EXCLUDED.next_renewal_date,
+				EXCLUDED.validation_sources,
+				EXCLUDED.source_file_id
+			)
+	`, values)
+}
+
+func (r *leiRepository) BatchUpdateLEILinkReferences(records []*domain.LEIRecord) (int, error) {
+	if len(records) == 0 {
+		return 0, nil
+	}
+
+	updatedCount := 0
+	const batchSize = 250
+
+	for i := 0; i < len(records); i += batchSize {
+		end := i + batchSize
+		if end > len(records) {
+			end = len(records)
+		}
+
+		batch := records[i:end]
+		valueStrings := make([]string, 0, len(batch))
+		valueArgs := make([]interface{}, 0, len(batch)*3)
+
+		for _, record := range batch {
+			valueStrings = append(valueStrings, "(?, ?, ?)")
+			valueArgs = append(valueArgs,
+				record.LEI,
+				nullableLEICode(record.SuccessorLEI),
+				nullableCode(record.ManagingLOU),
+			)
+		}
+
+		stmt := buildLEILinkReferenceUpdateSQL(strings.Join(valueStrings, ","))
+
+		result := r.db.Exec(stmt, valueArgs...)
+		if result.Error != nil {
+			return updatedCount, fmt.Errorf("failed to reconcile LEI link references for records %d-%d: %w", i, end, result.Error)
+		}
+
+		updatedCount += int(result.RowsAffected)
+	}
+
+	return updatedCount, nil
+}
+
+func buildLEILinkReferenceUpdateSQL(values string) string {
+	return fmt.Sprintf(`
+			WITH link_updates (lei, successor_lei, managing_lou) AS (
+				VALUES %s
+			)
+			UPDATE lei_raw.lei_records AS current
+			SET
+				successor_lei = link_updates.successor_lei,
+				managing_lou = link_updates.managing_lou,
+				updated_at = NOW(),
+				updated_by = 'system'
+			FROM link_updates
+			WHERE current.lei = link_updates.lei
+				AND (
+					current.successor_lei,
+					current.managing_lou
+				) IS DISTINCT FROM (
+					link_updates.successor_lei,
+					link_updates.managing_lou
+				)
+	`, values)
 }
 
 // DeleteLEI soft deletes an LEI record

--- a/backend/internal/repository/lei_repository.go
+++ b/backend/internal/repository/lei_repository.go
@@ -1363,6 +1363,7 @@ func (r *leiRepository) BatchUpdateLEILinkReferences(records []*domain.LEIRecord
 		batch := records[i:end]
 		valueStrings := make([]string, 0, len(batch))
 		valueArgs := make([]interface{}, 0, len(batch)*3)
+		affectedLEIs := make([]string, 0, len(batch))
 
 		for _, record := range batch {
 			valueStrings = append(valueStrings, "(?, ?, ?)")
@@ -1371,16 +1372,53 @@ func (r *leiRepository) BatchUpdateLEILinkReferences(records []*domain.LEIRecord
 				nullableLEICode(record.SuccessorLEI),
 				nullableCode(record.ManagingLOU),
 			)
+			affectedLEIs = append(affectedLEIs, record.LEI)
 		}
 
 		stmt := buildLEILinkReferenceUpdateSQL(strings.Join(valueStrings, ","))
 
-		result := r.db.Exec(stmt, valueArgs...)
+		// Execute the UPDATE and capture which records were actually modified
+		var updatedRecords []struct {
+			ID  uuid.UUID
+			LEI string
+		}
+		result := r.db.Raw(stmt, valueArgs...).Scan(&updatedRecords)
 		if result.Error != nil {
 			return updatedCount, fmt.Errorf("failed to reconcile LEI link references for records %d-%d: %w", i, end, result.Error)
 		}
 
-		updatedCount += int(result.RowsAffected)
+		batchUpdatedCount := len(updatedRecords)
+		updatedCount += batchUpdatedCount
+
+		// Create audit records for updated links
+		if batchUpdatedCount > 0 {
+			auditRecords := make([]domain.LEIRecordAudit, 0, len(updatedRecords))
+			changedFieldsJSON := []byte(`{"successor_lei":true,"managing_lou":true}`)
+
+			for _, rec := range updatedRecords {
+				auditRecords = append(auditRecords, domain.LEIRecordAudit{
+					LEIRecordID:    rec.ID,
+					LEI:            rec.LEI,
+					Action:         "UPDATE",
+					RecordSnapshot: "{}",
+					ChangedFields:  domain.JSONBString(changedFieldsJSON),
+					ChangedBy:      "system",
+				})
+			}
+
+			// Batch insert audit records
+			auditBatchSize := 100
+			for j := 0; j < len(auditRecords); j += auditBatchSize {
+				auditEnd := j + auditBatchSize
+				if auditEnd > len(auditRecords) {
+					auditEnd = len(auditRecords)
+				}
+
+				if err := r.db.Create(auditRecords[j:auditEnd]).Error; err != nil {
+					return updatedCount, fmt.Errorf("failed to create link update audit records: %w", err)
+				}
+			}
+		}
 	}
 
 	return updatedCount, nil
@@ -1388,24 +1426,25 @@ func (r *leiRepository) BatchUpdateLEILinkReferences(records []*domain.LEIRecord
 
 func buildLEILinkReferenceUpdateSQL(values string) string {
 	return fmt.Sprintf(`
-			WITH link_updates (lei, successor_lei, managing_lou) AS (
-				VALUES %s
+		WITH link_updates (lei, successor_lei, managing_lou) AS (
+			VALUES %s
+		)
+		UPDATE lei_raw.lei_records AS current
+		SET
+			successor_lei = link_updates.successor_lei,
+			managing_lou = link_updates.managing_lou,
+			updated_at = NOW(),
+			updated_by = 'system'
+		FROM link_updates
+		WHERE current.lei = link_updates.lei
+			AND (
+				current.successor_lei,
+				current.managing_lou
+			) IS DISTINCT FROM (
+				link_updates.successor_lei,
+				link_updates.managing_lou
 			)
-			UPDATE lei_raw.lei_records AS current
-			SET
-				successor_lei = link_updates.successor_lei,
-				managing_lou = link_updates.managing_lou,
-				updated_at = NOW(),
-				updated_by = 'system'
-			FROM link_updates
-			WHERE current.lei = link_updates.lei
-				AND (
-					current.successor_lei,
-					current.managing_lou
-				) IS DISTINCT FROM (
-					link_updates.successor_lei,
-					link_updates.managing_lou
-				)
+		RETURNING current.id, current.lei
 	`, values)
 }
 
@@ -1675,10 +1714,13 @@ func (r *leiRepository) detectChanges(old, new *domain.LEIRecord) map[string]dom
 		field := oldType.Field(i)
 		fieldName := field.Name
 
-		// Skip internal fields and timestamps
-		if fieldName == "ID" || fieldName == "CreatedAt" || fieldName == "UpdatedAt" ||
-			fieldName == "DeletedAt" || fieldName == "CreatedBy" || fieldName == "UpdatedBy" ||
-			fieldName == "ChangedFields" || fieldName == "SourceFile" || fieldName == "SourceFileID" {
+// Skip internal fields, timestamps, and deferred self-referential link fields
+	// (successor_lei and managing_lou are reconciled in a separate post-pass, so they
+	// should not trigger change detection during the primary upsert)
+	if fieldName == "ID" || fieldName == "CreatedAt" || fieldName == "UpdatedAt" ||
+		fieldName == "DeletedAt" || fieldName == "CreatedBy" || fieldName == "UpdatedBy" ||
+		fieldName == "ChangedFields" || fieldName == "SourceFile" || fieldName == "SourceFileID" ||
+		fieldName == "SuccessorLEI" || fieldName == "ManagingLOU" {
 			continue
 		}
 

--- a/backend/internal/repository/lei_repository_batch_upsert_test.go
+++ b/backend/internal/repository/lei_repository_batch_upsert_test.go
@@ -1,0 +1,30 @@
+package repository
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBatchUpsertLEIRecords_DefersSelfReferentialColumns(t *testing.T) {
+	stmt := buildLEIRecordBatchUpsertSQL("(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+
+	if strings.Contains(stmt, "successor_lei") {
+		t.Fatalf("expected primary upsert SQL to defer successor_lei, got: %s", stmt)
+	}
+
+	if strings.Contains(stmt, "managing_lou") {
+		t.Fatalf("expected primary upsert SQL to defer managing_lou, got: %s", stmt)
+	}
+}
+
+func TestBatchUpdateLEILinkReferences_SQLShape(t *testing.T) {
+	stmt := buildLEILinkReferenceUpdateSQL("(?, ?, ?)")
+
+	if !strings.Contains(stmt, "successor_lei = link_updates.successor_lei") {
+		t.Fatalf("expected reconciliation SQL to update successor_lei, got: %s", stmt)
+	}
+
+	if !strings.Contains(stmt, "managing_lou = link_updates.managing_lou") {
+		t.Fatalf("expected reconciliation SQL to update managing_lou, got: %s", stmt)
+	}
+}

--- a/backend/internal/service/lei_service.go
+++ b/backend/internal/service/lei_service.go
@@ -822,7 +822,11 @@ func (s *leiService) processJSONFile(jsonPath string, sourceFile *domain.SourceF
 				Str("source_file_id", sourceFile.ID.String()).
 				Msg("Found records array, starting record processing")
 			// Found the records array, start processing
-			return s.processRecordsArray(decoder, sourceFile, resumeFromLEI)
+			if err := s.processRecordsArray(decoder, sourceFile, resumeFromLEI); err != nil {
+				return err
+			}
+
+			return s.reconcileLEILinkReferences(jsonPath, sourceFile)
 		}
 
 		// Skip the value for non-records keys
@@ -833,6 +837,118 @@ func (s *leiService) processJSONFile(jsonPath string, sourceFile *domain.SourceF
 	}
 
 	return fmt.Errorf("records array not found in JSON file")
+}
+
+func (s *leiService) reconcileLEILinkReferences(jsonPath string, sourceFile *domain.SourceFile) error {
+	log.Info().
+		Str("file", jsonPath).
+		Str("source_file_id", sourceFile.ID.String()).
+		Msg("Starting LEI self-reference reconciliation pass")
+
+	file, err := os.Open(jsonPath)
+	if err != nil {
+		return fmt.Errorf("failed to open JSON file for LEI link reconciliation: %w", err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Error().Err(err).Msg("Failed to close JSON file after LEI link reconciliation")
+		}
+	}()
+
+	decoder := json.NewDecoder(file)
+	token, err := decoder.Token()
+	if err != nil {
+		return fmt.Errorf("failed to read opening brace for LEI link reconciliation: %w", err)
+	}
+	if delim, ok := token.(json.Delim); !ok || delim != '{' {
+		return fmt.Errorf("expected '{' during LEI link reconciliation, got %v", token)
+	}
+
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("failed to read token during LEI link reconciliation: %w", err)
+		}
+
+		key, ok := token.(string)
+		if !ok {
+			return fmt.Errorf("expected JSON object key during LEI link reconciliation, got %T", token)
+		}
+
+		if key != "records" {
+			var skipValue interface{}
+			if err := decoder.Decode(&skipValue); err != nil {
+				return fmt.Errorf("failed to skip non-records value during LEI link reconciliation: %w", err)
+			}
+			continue
+		}
+
+		return s.reconcileLEILinkReferencesArray(decoder, sourceFile)
+	}
+
+	return fmt.Errorf("records array not found during LEI link reconciliation")
+}
+
+func (s *leiService) reconcileLEILinkReferencesArray(decoder *json.Decoder, sourceFile *domain.SourceFile) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return fmt.Errorf("failed to read records array during LEI link reconciliation: %w", err)
+	}
+	if delim, ok := token.(json.Delim); !ok || delim != '[' {
+		return fmt.Errorf("expected '[' during LEI link reconciliation, got %v", token)
+	}
+
+	const batchSize = 1000
+	records := make([]*domain.LEIRecord, 0, batchSize)
+	totalUpdated := 0
+	recordCount := 0
+
+	flushBatch := func() error {
+		if len(records) == 0 {
+			return nil
+		}
+
+		updated, err := s.repo.BatchUpdateLEILinkReferences(records)
+		if err != nil {
+			return fmt.Errorf("failed to reconcile LEI link references: %w", err)
+		}
+
+		totalUpdated += updated
+		records = records[:0]
+		return nil
+	}
+
+	for decoder.More() {
+		recordCount++
+		var jsonRecord LEIJSONRecord
+		if err := decoder.Decode(&jsonRecord); err != nil {
+			return fmt.Errorf("failed to decode LEI JSON record during link reconciliation at record %d: %w", recordCount, err)
+		}
+
+		record := s.jsonToDomainRecord(&jsonRecord, sourceFile.ID)
+		if !isValidLEICode(record.LEI) {
+			continue
+		}
+
+		records = append(records, record)
+		if len(records) >= batchSize {
+			if err := flushBatch(); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := flushBatch(); err != nil {
+		return err
+	}
+
+	log.Info().
+		Str("source_file_id", sourceFile.ID.String()).
+		Int("records_scanned", recordCount).
+		Int("records_updated", totalUpdated).
+		Msg("Completed LEI self-reference reconciliation pass")
+
+	return nil
 }
 
 // processRecordsArray processes the records array from the JSON decoder using batch processing

--- a/backend/internal/service/lei_service_test.go
+++ b/backend/internal/service/lei_service_test.go
@@ -673,12 +673,18 @@ type processRecordsRepoStub struct {
 	updateCalls           int
 	updateSnapshots       []domain.SourceFile
 	batchUpsertCallCount  int
+	batchLinkUpdateCalls  int
 	batchResolveCallCount int
 }
 
 func (s *processRecordsRepoStub) BatchUpsertLEIRecords(records []*domain.LEIRecord) (int, int, error) {
 	s.batchUpsertCallCount++
 	return len(records), 0, nil
+}
+
+func (s *processRecordsRepoStub) BatchUpdateLEILinkReferences(records []*domain.LEIRecord) (int, error) {
+	s.batchLinkUpdateCalls++
+	return len(records), nil
 }
 
 func (s *processRecordsRepoStub) BatchResolveOpenProcessingFailures(jobType string, naturalKeys []string, resolvedSourceFileID *uuid.UUID, resolvedNote string) error {
@@ -746,6 +752,10 @@ func TestProcessRecordsArray_CheckpointUpdatesAtConfiguredInterval(t *testing.T)
 		t.Fatalf("expected 11 batch upsert calls for 10001 records at batchSize=1000, got %d", repoStub.batchUpsertCallCount)
 	}
 
+	if repoStub.batchLinkUpdateCalls != 0 {
+		t.Fatalf("expected no link reconciliation calls during processRecordsArray, got %d", repoStub.batchLinkUpdateCalls)
+	}
+
 	finalSnapshot := repoStub.updateSnapshots[len(repoStub.updateSnapshots)-1]
 	if finalSnapshot.LastProcessedLEI == nil {
 		t.Fatalf("expected final LastProcessedLEI to be persisted")
@@ -781,6 +791,43 @@ func TestProcessRecordsArray_FinalUpdatePersistsLastProcessedLEIForSmallFiles(t 
 	wantLastLEI := testLEICodeForIndex(recordCount - 1)
 	if *finalSnapshot.LastProcessedLEI != wantLastLEI {
 		t.Fatalf("expected LastProcessedLEI %q, got %q", wantLastLEI, *finalSnapshot.LastProcessedLEI)
+	}
+}
+
+func TestProcessJSONFile_ReconcilesSelfReferencesAfterPrimaryLoad(t *testing.T) {
+	repoStub := &processRecordsRepoStub{}
+	svc := &leiService{repo: repoStub}
+
+	jsonPath := filepath.Join(t.TempDir(), "records.json")
+	jsonBody := `{"header":{"contentDate":"2026-05-06"},"records":[{"LEI":{"$":"5493001KJTIIGC8Y1R12"},"Entity":{"LegalName":{"$":"Alpha Ltd"},"SuccessorEntity":[{"SuccessorLEI":{"$":"549300PSS2MPL4W02719"}}]},"Registration":{"ManagingLOU":{"$":"549300PSS2MPL4W02719"}}},{"LEI":{"$":"549300PSS2MPL4W02719"},"Entity":{"LegalName":{"$":"Beta Ltd"}},"Registration":{}}]}`
+	if err := os.WriteFile(jsonPath, []byte(jsonBody), 0o600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	sourceFile := &domain.SourceFile{ID: uuid.New(), TotalRecords: 2}
+	if err := svc.processJSONFile(jsonPath, sourceFile, ""); err != nil {
+		t.Fatalf("processJSONFile returned error: %v", err)
+	}
+
+	if repoStub.batchUpsertCallCount != 1 {
+		t.Fatalf("expected 1 primary batch upsert call, got %d", repoStub.batchUpsertCallCount)
+	}
+
+	if repoStub.batchLinkUpdateCalls != 1 {
+		t.Fatalf("expected 1 link reconciliation call, got %d", repoStub.batchLinkUpdateCalls)
+	}
+
+	if repoStub.updateCalls == 0 {
+		t.Fatalf("expected source file updates to be persisted")
+	}
+
+	finalSnapshot := repoStub.updateSnapshots[len(repoStub.updateSnapshots)-1]
+	if finalSnapshot.LastProcessedLEI == nil || *finalSnapshot.LastProcessedLEI != "549300PSS2MPL4W02719" {
+		t.Fatalf("expected final LastProcessedLEI to be last record, got %+v", finalSnapshot.LastProcessedLEI)
+	}
+
+	if finalSnapshot.ProcessedRecords != 2 {
+		t.Fatalf("expected ProcessedRecords=2, got %d", finalSnapshot.ProcessedRecords)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fix Level 1 full sync failures caused by self-referential FK writes during primary batch upsert.

## What Changed
- Split Level 1 self-referential writes into a staged reconciliation flow.
- Excluded `successor_lei` and `managing_lou` from primary batch upsert SQL.
- Added a batched post-ingest reconciliation update for those link fields.
- Added repository and service regression tests for staged-write behavior.

## Validation
- `go test -count=1 ./internal/repository ./internal/service`
- Main container runtime validation: Level 1 completed with `processed_records=3299791` and `failed_records=0`.

Refs #492
