### PR TITLE
fix: normalize blank/NULL link references to prevent false-positive audits

### DIFF
--- a/backend/internal/repository/lei_repository.go
+++ b/backend/internal/repository/lei_repository.go
@@ -1424,8 +1424,15 @@ func (r *leiRepository) BatchUpdateLEILinkReferences(records []*domain.LEIRecord
 
 func buildLEILinkReferenceUpdateSQL(values string) string {
 	return fmt.Sprintf(`
-		WITH link_updates (lei, successor_lei, managing_lou) AS (
+		WITH link_updates_raw (lei, successor_lei, managing_lou) AS (
 			VALUES %s
+		),
+		link_updates AS (
+			SELECT
+				BTRIM(lei::text) AS lei,
+				NULLIF(BTRIM(successor_lei::text), '') AS successor_lei,
+				NULLIF(BTRIM(managing_lou::text), '') AS managing_lou
+			FROM link_updates_raw
 		)
 		UPDATE lei_raw.lei_records AS current
 		SET
@@ -1436,8 +1443,8 @@ func buildLEILinkReferenceUpdateSQL(values string) string {
 		FROM link_updates
 		WHERE current.lei = link_updates.lei
 			AND (
-				current.successor_lei,
-				current.managing_lou
+				NULLIF(BTRIM(COALESCE(current.successor_lei, '')), ''),
+				NULLIF(BTRIM(COALESCE(current.managing_lou, '')), '')
 			) IS DISTINCT FROM (
 				link_updates.successor_lei,
 				link_updates.managing_lou

--- a/backend/internal/repository/lei_repository_batch_upsert_test.go
+++ b/backend/internal/repository/lei_repository_batch_upsert_test.go
@@ -27,4 +27,20 @@ func TestBatchUpdateLEILinkReferences_SQLShape(t *testing.T) {
 	if !strings.Contains(stmt, "managing_lou = link_updates.managing_lou") {
 		t.Fatalf("expected reconciliation SQL to update managing_lou, got: %s", stmt)
 	}
+
+	if !strings.Contains(stmt, "NULLIF(BTRIM(successor_lei::text), '')") {
+		t.Fatalf("expected reconciliation SQL to normalize blank successor_lei values, got: %s", stmt)
+	}
+
+	if !strings.Contains(stmt, "NULLIF(BTRIM(managing_lou::text), '')") {
+		t.Fatalf("expected reconciliation SQL to normalize blank managing_lou values, got: %s", stmt)
+	}
+
+	if !strings.Contains(stmt, "NULLIF(BTRIM(COALESCE(current.successor_lei, '')), '')") {
+		t.Fatalf("expected reconciliation SQL to compare normalized successor_lei values, got: %s", stmt)
+	}
+
+	if !strings.Contains(stmt, "NULLIF(BTRIM(COALESCE(current.managing_lou, '')), '')") {
+		t.Fatalf("expected reconciliation SQL to compare normalized managing_lou values, got: %s", stmt)
+	}
 }


### PR DESCRIPTION
## Problem

Level 1 LEI record updates for link references (Managing LOU and Successor LEI) were recording audit rows with stated field changes even when no actual change occurred. Root cause: `buildLEILinkReferenceUpdateSQL` did not normalize blank strings to NULL before comparison, causing `""` vs `NULL` to be flagged as a change despite both meaning "no value."

Impact: 280+ false-positive audit entries on 2026-05-06 alone.

## Solution

- Fixed `buildLEILinkReferenceUpdateSQL` to normalize incoming link fields via `NULLIF(BTRIM(...), '')`
- Normalized existing database values using the same logic in IS DISTINCT FROM comparison
- Added test assertions to `TestBatchUpdateLEILinkReferences_SQLShape` to prevent regression

## Changes

- `backend/internal/repository/lei_repository.go` (line 1427): Updated `buildLEILinkReferenceUpdateSQL` with CTE normalization
- `backend/internal/repository/lei_repository_batch_upsert_test.go` (line 20): Added normalization test assertions

## Cleanup Completed

- Deleted 280 false-positive audit rows from axiom_main (2026-05-06 UTC)
- Post-delete verification: 0 remaining no-op rows; legitimate updates unaffected

## Testing

- Unit tests pass: `go test ./internal/repository -run "BatchUpdateLEILinkReferences|BatchUpsertLEIRecords"`
- Test assertions verify blank/null normalization behavior

Fixes #506
Related to #493