### PR TITLE
fix: backport hook guard removal, migration comment fix, and i18n error key from PR #513

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,28 @@
 #!/bin/sh
 # Pre-push hook to ensure VS Code settings are sorted.
 
+zero_sha="0000000000000000000000000000000000000000"
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+    local_ref=$(printf '%s' "$local_ref" | tr -d '\r')
+    local_sha=$(printf '%s' "$local_sha" | tr -d '\r')
+    remote_ref=$(printf '%s' "$remote_ref" | tr -d '\r')
+    remote_sha=$(printf '%s' "$remote_sha" | tr -d '\r')
+
+    [ -z "$local_sha" ] && continue
+    [ "$local_sha" = "$zero_sha" ] && continue
+
+    if [ "$remote_sha" = "$zero_sha" ]; then
+        range="$local_sha --not --remotes"
+    else
+        range="$remote_sha..$local_sha"
+    fi
+
+    if [ -z "$(git rev-list -n 1 $range)" ]; then
+        continue
+    fi
+done
+
 if [ ! -f ".vscode/settings.json" ]; then
     exit 0
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,28 +1,6 @@
 #!/bin/sh
 # Pre-push hook to ensure VS Code settings are sorted.
 
-zero_sha="0000000000000000000000000000000000000000"
-
-while read -r local_ref local_sha remote_ref remote_sha; do
-    local_ref=$(printf '%s' "$local_ref" | tr -d '\r')
-    local_sha=$(printf '%s' "$local_sha" | tr -d '\r')
-    remote_ref=$(printf '%s' "$remote_ref" | tr -d '\r')
-    remote_sha=$(printf '%s' "$remote_sha" | tr -d '\r')
-
-    [ -z "$local_sha" ] && continue
-    [ "$local_sha" = "$zero_sha" ] && continue
-
-    if [ "$remote_sha" = "$zero_sha" ]; then
-        range="$local_sha --not --remotes"
-    else
-        range="$remote_sha..$local_sha"
-    fi
-
-    if [ -z "$(git rev-list -n 1 $range)" ]; then
-        continue
-    fi
-done
-
 if [ ! -f ".vscode/settings.json" ]; then
     exit 0
 fi

--- a/backend/migrations/000067_add_fk_user_entity_links_audit.down.sql
+++ b/backend/migrations/000067_add_fk_user_entity_links_audit.down.sql
@@ -1,5 +1,2 @@
 ALTER TABLE IF EXISTS user_entity_links_audit
 DROP CONSTRAINT IF EXISTS fk_user_entity_links_audit_link_id;
-
-COMMENT ON COLUMN user_entity_links_audit.user_entity_link_id IS
-'Foreign key to user_entity_links.id.';

--- a/frontend/app/admin/translations/page.tsx
+++ b/frontend/app/admin/translations/page.tsx
@@ -486,7 +486,7 @@ export default function AdminTranslationsPage() {
     // Validate translation value for unsafe nesting patterns
     const validation = validateTranslationValue(formData.translation_value)
     if (!validation.valid) {
-      setFormError(validation.error || t('admin.translations.errors.submitFailed'))
+      setFormError(validation.errorKey ? t(validation.errorKey) : t('admin.translations.errors.submitFailed'))
       return
     }
 

--- a/frontend/app/lib/translation-validation.test.ts
+++ b/frontend/app/lib/translation-validation.test.ts
@@ -6,43 +6,43 @@ describe('validateTranslationValue', () => {
     it('accepts empty string', () => {
       const result = validateTranslationValue('')
       expect(result.valid).toBe(true)
-      expect(result.error).toBeUndefined()
+      expect(result.errorKey).toBeUndefined()
     })
 
     it('accepts plain translation text without nesting', () => {
       const result = validateTranslationValue('Hello World')
       expect(result.valid).toBe(true)
-      expect(result.error).toBeUndefined()
+      expect(result.errorKey).toBeUndefined()
     })
 
     it('accepts simple $t() pointer with single key', () => {
       const result = validateTranslationValue('$t(home.title)')
       expect(result.valid).toBe(true)
-      expect(result.error).toBeUndefined()
+      expect(result.errorKey).toBeUndefined()
     })
 
     it('accepts $t() pointer with nested dot-separated key', () => {
       const result = validateTranslationValue('$t(reference.layout.header)')
       expect(result.valid).toBe(true)
-      expect(result.error).toBeUndefined()
+      expect(result.errorKey).toBeUndefined()
     })
 
     it('accepts plain text with spaces and special characters', () => {
       const result = validateTranslationValue('Welcome to Axiom! Please sign in.')
       expect(result.valid).toBe(true)
-      expect(result.error).toBeUndefined()
+      expect(result.errorKey).toBeUndefined()
     })
 
     it('accepts interpolation variables', () => {
       const result = validateTranslationValue('Hello {{name}}, welcome to {{appName}}')
       expect(result.valid).toBe(true)
-      expect(result.error).toBeUndefined()
+      expect(result.errorKey).toBeUndefined()
     })
 
     it('accepts multiple $t() pointers in same string', () => {
       const result = validateTranslationValue('$t(prefix.label) - $t(suffix.label)')
       expect(result.valid).toBe(true)
-      expect(result.error).toBeUndefined()
+      expect(result.errorKey).toBeUndefined()
     })
   })
 

--- a/frontend/app/lib/translation-validation.test.ts
+++ b/frontend/app/lib/translation-validation.test.ts
@@ -50,37 +50,37 @@ describe('validateTranslationValue', () => {
     it('rejects $t() with comma-separated arguments', () => {
       const result = validateTranslationValue('$t(key, "fallback")')
       expect(result.valid).toBe(false)
-      expect(result.error).toContain('Unsafe nesting options detected')
+      expect(result.errorKey).toBe('admin.translations.errors.validation.unsafeNestingOptions')
     })
 
     it('rejects $t() with option object block', () => {
       const result = validateTranslationValue('$t(reference.key, {"x":"{{userInput}}"})')
       expect(result.valid).toBe(false)
-      expect(result.error).toContain('Unsafe nesting options detected')
+      expect(result.errorKey).toBe('admin.translations.errors.validation.unsafeNestingOptions')
     })
 
     it('rejects $t() with array syntax', () => {
       const result = validateTranslationValue('$t(key, [1, 2, 3])')
       expect(result.valid).toBe(false)
-      expect(result.error).toContain('Unsafe nesting options detected')
+      expect(result.errorKey).toBe('admin.translations.errors.validation.unsafeNestingOptions')
     })
 
     it('rejects $t() with nested curly braces for default value', () => {
       const result = validateTranslationValue('$t(key, {defaultValue: "text"})')
       expect(result.valid).toBe(false)
-      expect(result.error).toContain('Unsafe nesting options detected')
+      expect(result.errorKey).toBe('admin.translations.errors.validation.unsafeNestingOptions')
     })
 
     it('rejects $t() with simple key and empty object', () => {
       const result = validateTranslationValue('$t(some.key, {})')
       expect(result.valid).toBe(false)
-      expect(result.error).toContain('Unsafe nesting options detected')
+      expect(result.errorKey).toBe('admin.translations.errors.validation.unsafeNestingOptions')
     })
 
     it('rejects complex nesting with context object', () => {
       const result = validateTranslationValue('$t(key, {context: "plural"})')
       expect(result.valid).toBe(false)
-      expect(result.error).toContain('Unsafe nesting options detected')
+      expect(result.errorKey).toBe('admin.translations.errors.validation.unsafeNestingOptions')
     })
   })
 
@@ -88,25 +88,25 @@ describe('validateTranslationValue', () => {
     it('accepts $t() at start of string with plain text after', () => {
       const result = validateTranslationValue('$t(nav.home) or visit our website')
       expect(result.valid).toBe(true)
-      expect(result.error).toBeUndefined()
+      expect(result.errorKey).toBeUndefined()
     })
 
     it('accepts mixed plain text and pointer', () => {
       const result = validateTranslationValue('See $t(help.docs) for more info')
       expect(result.valid).toBe(true)
-      expect(result.error).toBeUndefined()
+      expect(result.errorKey).toBeUndefined()
     })
 
     it('handles whitespace within pointer', () => {
       const result = validateTranslationValue('$t( some . key )')
       expect(result.valid).toBe(true)
-      expect(result.error).toBeUndefined()
+      expect(result.errorKey).toBeUndefined()
     })
 
     it('rejects even if unsafe pattern is in middle of string', () => {
       const result = validateTranslationValue('Please see $t(key, {option: "value"}) for details')
       expect(result.valid).toBe(false)
-      expect(result.error).toContain('Unsafe nesting options detected')
+      expect(result.errorKey).toBe('admin.translations.errors.validation.unsafeNestingOptions')
     })
   })
 })

--- a/frontend/app/lib/translation-validation.ts
+++ b/frontend/app/lib/translation-validation.ts
@@ -5,7 +5,7 @@
  * like $t(key, {...}) from being stored in translation inputs.
  */
 
-export const validateTranslationValue = (value: string): { valid: boolean; error?: string } => {
+export const validateTranslationValue = (value: string): { valid: boolean; errorKey?: string } => {
   if (!value) return { valid: true }
 
   // Check if value contains $t(...) nesting syntax
@@ -20,9 +20,7 @@ export const validateTranslationValue = (value: string): { valid: boolean; error
       if (content.includes(',') || content.includes('{') || content.includes('[')) {
         return {
           valid: false,
-          error:
-            'Unsafe nesting options detected. Use simple pointer form: $t(key) or $t(some.nested.key). ' +
-            'Option blocks like $t(key, {...}) are not allowed.',
+          errorKey: 'admin.translations.errors.validation.unsafeNestingOptions',
         }
       }
     }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -182,12 +182,6 @@
     "translations": {
       "title": "$t(leftNav.items.adminTranslations)",
       "subtitle": "Manage UI translation strings across all supported languages",
-      "errors": {
-        "submitFailed": "Failed to save translation",
-        "validation": {
-          "unsafeNestingOptions": "Unsafe nesting options detected. Use simple pointer form: $t(key) or $t(some.nested.key). Option blocks like $t(key, {...}) are not allowed."
-        }
-      },
       "addTranslation": "Add Translation",
       "searchPlaceholder": "Search by key or value…",
       "filterByLanguage": "Filter by language",
@@ -261,7 +255,10 @@
         "approveFailed": "Failed to approve translation",
         "rejectFailed": "Failed to reject translation",
         "deleteFailed": "Failed to delete translation",
-        "submitFailed": "Failed to submit"
+        "submitFailed": "Failed to save translation",
+        "validation": {
+          "unsafeNestingOptions": "Unsafe nesting options detected. Use simple pointer form: $t(key) or $t(some.nested.key). Option blocks like $t(key, {...}) are not allowed."
+        }
       }
     },
     "users": {

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -182,6 +182,12 @@
     "translations": {
       "title": "$t(leftNav.items.adminTranslations)",
       "subtitle": "Manage UI translation strings across all supported languages",
+      "errors": {
+        "submitFailed": "Failed to save translation",
+        "validation": {
+          "unsafeNestingOptions": "Unsafe nesting options detected. Use simple pointer form: $t(key) or $t(some.nested.key). Option blocks like $t(key, {...}) are not allowed."
+        }
+      },
       "addTranslation": "Add Translation",
       "searchPlaceholder": "Search by key or value…",
       "filterByLanguage": "Filter by language",


### PR DESCRIPTION
﻿Backports three fixes from PR #513 (dev realignment) to main so they are not lost until dev is promoted.

## Changes

### 1. Remove next-env.d.ts guards from git hooks

- Removed commit-block guard from .githooks/pre-commit (redundant since #505 gitignored the file)
- Removed push-block guard from .githooks/pre-push (same reason)
- Added the while-read loop structure to .githooks/pre-push from dev (was only on dev)

### 2. Fix misleading FK comment in down migration

- Removed COMMENT ON COLUMN from backend/migrations/000067_add_fk_user_entity_links_audit.down.sql
  that described the column as a foreign key, which is inaccurate after rollback drops the constraint

### 3. i18n: validateTranslationValue uses error key not hardcoded string

- Changed return type from error: string to errorKey: string
- Added i18n entry admin.translations.errors.validation.unsafeNestingOptions to common.json
- Updated call site in frontend/app/admin/translations/page.tsx to translate via t()
- Updated all tests in translation-validation.test.ts

## Why backport now?

These fixes exist on fix/dev-realignment-from-main (PR #513) but not on main.
Without this PR, main retains the hook guards, the misleading migration comment,
and the hardcoded error string until dev is promoted, which may be days away.

Backports: #513