### PR TITLE
chore: skip backport check for forward-merge promotion PRs

### DIFF
--- a/.github/workflows/check-hotfix-backport.yml
+++ b/.github/workflows/check-hotfix-backport.yml
@@ -28,6 +28,7 @@ jobs:
           script: |
             const pr = context.payload.pull_request
             const base = pr.base.ref
+            const head = pr.head.ref
             const labels = (pr.labels || []).map((l) =>
               (typeof l === 'string' ? l : l.name).toLowerCase()
             )
@@ -45,6 +46,23 @@ jobs:
 
             if (!isEnvTarget || !isHotfix) {
               core.info('Not a hotfix/emergency PR targeting an env branch; skipping backport check.')
+              return
+            }
+
+            // Skip backport check for forward-merge promotion PRs.
+            // These PRs merge changes from source branch into destination env branch atomically.
+            // All changes are already on source; destination gets them via the merge.
+            // No backport needed because the merge IS the promotion.
+            const isForwardMerge =
+              (base === 'dev' && head === 'main') ||
+              (base === 'uat' && head === 'dev') ||
+              (base === 'prod' && head === 'uat')
+
+            if (isForwardMerge) {
+              core.info(
+                `Forward-merge promotion PR (${head} → ${base}); backport check skipped. ` +
+                `Changes are promoted atomically via the merge.`
+              )
               return
             }
 


### PR DESCRIPTION
﻿Fixes #518

## Problem

The hotfix backport check was incorrectly requiring backports for forward-merge promotion PRs (main→dev, dev→uat, uat→prod). These PRs don't need backports because they promote changes atomically.

## Changes

Modified .github/workflows/check-hotfix-backport.yml to detect forward-merge promotion PRs and skip the backport requirement for them.

**Detection logic:**
- If base=dev and head=main → forward-merge, skip backport check
- If base=uat and head=dev → forward-merge, skip backport check
- If base=prod and head=uat → forward-merge, skip backport check

## Rationale

- Forward-merges promote all changes atomically from source to destination
- Changes are already on the source branch; destination gets them all or nothing
- No backport needed because the merge itself IS the promotion
- Only true hotfixes (new changes added directly to env branches) require backports

Eliminates false positives on PR #515, #517, and future daily promotion cycles.