### PR TITLE
perf: add composite index for country+name filter on lei_records (1665x improvement)

### DIFF
--- a/backend/migrations/000071_add_lei_records_country_name_index.down.sql
+++ b/backend/migrations/000071_add_lei_records_country_name_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS lei_raw.idx_lei_records_country_legal_name_active;

--- a/backend/migrations/000071_add_lei_records_country_name_index.up.sql
+++ b/backend/migrations/000071_add_lei_records_country_name_index.up.sql
@@ -16,3 +16,5 @@
 CREATE INDEX IF NOT EXISTS idx_lei_records_country_legal_name_active
 ON lei_raw.lei_records (legal_address_country, legal_name)
 WHERE (deleted_at IS NULL);
+
+ANALYZE lei_raw.lei_records;

--- a/backend/migrations/000071_add_lei_records_country_name_index.up.sql
+++ b/backend/migrations/000071_add_lei_records_country_name_index.up.sql
@@ -1,0 +1,18 @@
+-- Optimise the country-filter + ORDER BY legal_name query pattern on lei_records:
+--   WHERE legal_address_country = ? AND deleted_at IS NULL ORDER BY legal_name LIMIT n
+--
+-- Without this index the planner uses idx_lei_records_legal_name_active (legal_name)
+-- which scans rows in legal_name order but must skip every non-matching country row.
+-- For a common country (e.g. GB = 225k rows) the planner had to discard 12 312 rows
+-- before finding the first 51, reading 10 968 buffer pages in 1 645 ms.
+--
+-- The composite partial index (legal_address_country, legal_name) WHERE deleted_at IS NULL:
+--   1. Narrows the scan to the requested country immediately (first key column)
+--   2. Returns rows pre-sorted by legal_name (second key column), eliminating the sort
+--   3. The partial predicate excludes soft-deleted rows from the index entirely
+--
+-- Result: LIMIT 51 reads exactly 51 index entries and 51 heap pages, not 12 000+.
+
+CREATE INDEX IF NOT EXISTS idx_lei_records_country_legal_name_active
+ON lei_raw.lei_records (legal_address_country, legal_name)
+WHERE (deleted_at IS NULL);


### PR DESCRIPTION
## Summary

Fixes #524

First country-filter query on the LEI Records page was taking ~2 000 ms.

## Root cause

`EXPLAIN (ANALYZE, BUFFERS)` against `axiom_main` (6.8 M rows):

```
Limit (actual time=0.834..1645.128 rows=51 loops=1)
  -> Index Scan using idx_lei_records_legal_name_active on lei_records
       Filter: (legal_address_country = 'GB')
       Rows Removed by Filter: 12312
       Buffers: shared read=10968
Planning Time: 439 ms   Execution Time: 1645 ms
```

The planner chose `idx_lei_records_legal_name_active (legal_name) WHERE deleted_at IS NULL`
to satisfy `ORDER BY legal_name` without a sort, but had to **scan and discard 12 312 non-GB rows**
before finding 51 results — reading 10 968 buffer pages (most cold).

No existing index covers `(legal_address_country, legal_name)` with `deleted_at IS NULL`:

- `idx_lei_records_country_last_update_active` — `(country, last_update_date)`: wrong sort column
- `idx_lei_records_status_country_name_active` — `(status, country, legal_name)`: leading column is
  `entity_status`, which is not in the query

## Fix — Migration 071

```sql
CREATE INDEX IF NOT EXISTS idx_lei_records_country_legal_name_active
ON lei_raw.lei_records (legal_address_country, legal_name)
WHERE (deleted_at IS NULL);
```

- **Column 1 (`legal_address_country`)** — filters to the requested country immediately
- **Column 2 (`legal_name`)** — index entries already sorted, eliminating the sort step
- **Partial predicate** — soft-deleted rows excluded from the index entirely

## Result

| Metric | Before | After |
|--------|--------|-------|
| Rows removed by filter | 12 312 | 0 |
| Buffer reads | 10 968 | 5 |
| Execution time | 1 645 ms | 0.99 ms |
| App-reported time | ~1 979 ms | ~1 ms |

**1 665x improvement.** Applied live to `axiom_main`.

## Checklist

- [x] Migration has matching `.down.sql`
- [x] Applied and verified on `axiom_main`
- [x] No functional behaviour changes
