### PR TITLE
feat: add script shell parity instruction and PS1 counterparts for bash-only scripts

### DIFF
--- a/.github/instructions/script-shell-parity.instructions.md
+++ b/.github/instructions/script-shell-parity.instructions.md
@@ -1,0 +1,56 @@
+---
+description: >
+  Requires every script in scripts/ to have counterparts for both Bash (.sh) and
+  PowerShell (.ps1) unless the script is explicitly documented as intentionally
+  platform-specific (e.g. git-hook utilities that mandate pwsh).
+applyTo: 'scripts/**'
+---
+
+# Script Shell Parity
+
+## Rule
+
+Every script added to `scripts/` **must ship with a counterpart in the other shell
+flavour** in the same commit/PR:
+
+| New file         | Required counterpart |
+|------------------|----------------------|
+| `scripts/foo.sh` | `scripts/foo.ps1`    |
+| `scripts/foo.ps1`| `scripts/foo.sh`     |
+
+## Rationale
+
+The project runs on Windows (PowerShell 7+ / `pwsh`) and on Linux/macOS CI runners
+(bash).  Scripts that exist only for one platform block developers on the other and
+break `make` targets that try to detect the available shell.
+
+## Known intentional exceptions
+
+The following scripts are **intentionally PowerShell-only** because the project's
+`.githooks` explicitly require `pwsh` and document this requirement.  No bash
+counterpart is expected:
+
+| Script                        | Reason                                          |
+|-------------------------------|-------------------------------------------------|
+| `sort-ra-urls.ps1`            | Git hook utility — hook mandates `pwsh`         |
+| `sort-vscode-settings.ps1`    | Git hook utility — hook mandates `pwsh`         |
+
+If you add a new script that is intentionally platform-specific, add a row to the
+table above with a clear justification and get it reviewed in the PR.
+
+## Existing paired examples
+
+Refer to these paired scripts as style references when writing a new counterpart:
+
+- `ensure-bind-mounts.sh` / `ensure-bind-mounts.ps1`
+- `reset-frontend-state.sh` / `reset-frontend-state.ps1`
+- `run-main-compose.sh` / `run-main-compose.ps1`
+- `upgrade-postgres.sh` / `upgrade-postgres.ps1`
+
+## Checklist (apply when adding or reviewing scripts)
+
+- [ ] Both `.sh` and `.ps1` variants exist for the new script
+- [ ] Both variants implement the same flags / exit codes / output messages
+- [ ] `Makefile` references both (using the `ifeq ($(OS),Windows_NT)` or
+  `command -v bash / pwsh` detection pattern already in the file)
+- [ ] Any new exception is documented in the table above

--- a/.github/instructions/script-shell-parity.instructions.md
+++ b/.github/instructions/script-shell-parity.instructions.md
@@ -30,10 +30,10 @@ The following scripts are **intentionally PowerShell-only** because the project'
 `.githooks` explicitly require `pwsh` and document this requirement.  No bash
 counterpart is expected:
 
-| Script                        | Reason                                          |
-|-------------------------------|-------------------------------------------------|
-| `sort-ra-urls.ps1`            | Git hook utility — hook mandates `pwsh`         |
-| `sort-vscode-settings.ps1`    | Git hook utility — hook mandates `pwsh`         |
+| Script                             | Reason                                  |
+|------------------------------------|-----------------------------------------|
+| `scripts/sort-ra-urls.ps1`         | Git hook utility - hook mandates `pwsh` |
+| `scripts/sort-vscode-settings.ps1` | Git hook utility - hook mandates `pwsh` |
 
 If you add a new script that is intentionally platform-specific, add a row to the
 table above with a clear justification and get it reviewed in the PR.
@@ -50,7 +50,7 @@ Refer to these paired scripts as style references when writing a new counterpart
 ## Checklist (apply when adding or reviewing scripts)
 
 - [ ] Both `.sh` and `.ps1` variants exist for the new script
-- [ ] Both variants implement the same flags / exit codes / output messages
+- [ ] Both variants implement functionally equivalent flags / exit codes and comparable output messages
 - [ ] `Makefile` references both (using the `ifeq ($(OS),Windows_NT)` or
   `command -v bash / pwsh` detection pattern already in the file)
 - [ ] Any new exception is documented in the table above

--- a/docs/contributing/BRANCHING_STRATEGY.md
+++ b/docs/contributing/BRANCHING_STRATEGY.md
@@ -119,8 +119,21 @@ opens a pull request titled `chore: monthly promotion uat → prod (YYYY-MM-DD)`
 least two reviews** before merging. Coordinate with the team before merging — production
 deployments should be planned and communicated in advance. Version bumps are intentional and
 manual. If the release warrants a `PATCH`, `MINOR`, or `MAJOR` bump, apply it before the release
-merge using `pwsh ./scripts/bump-version.ps1 -Part patch`, `-Part minor`, or `-Part major`, then
-tag the promoted commit with that version. For exact test-state traceability, use the footer build
+merge using:
+
+**On Windows (PowerShell):**
+
+```powershell
+pwsh ./scripts/bump-version.ps1 -Part patch  # or -Part minor, -Part major
+```
+
+**On Linux/macOS:**
+
+```bash
+bash scripts/bump-version.sh --part patch   # or --part minor, --part major
+```
+
+Then tag the promoted commit with that version. For exact test-state traceability, use the footer build
 metadata tooltip (commit SHA + build timestamp).
 
 You can also trigger the workflow manually from **Actions → Monthly Promote uat → prod →
@@ -212,8 +225,16 @@ The following settings should be applied to `main`, `dev`, `uat`, and `prod` via
 Run the provided script. It requires the [GitHub CLI (`gh`)](https://cli.github.com/) and a token
 with `repo` and `admin:repo_hook` scopes:
 
+**On Linux/macOS:**
+
 ```bash
 bash scripts/setup-branches.sh
+```
+
+**On Windows (PowerShell):**
+
+```powershell
+pwsh ./scripts/setup-branches.ps1
 ```
 
 The script creates `dev`, `uat`, and `prod` from the current `main` HEAD and applies the branch

--- a/docs/contributing/BRANCHING_STRATEGY.md
+++ b/docs/contributing/BRANCHING_STRATEGY.md
@@ -130,7 +130,7 @@ pwsh ./scripts/bump-version.ps1 -Part patch  # or -Part minor, -Part major
 **On Linux/macOS:**
 
 ```bash
-bash scripts/bump-version.sh --part patch   # or --part minor, --part major
+bash scripts/bump-version.sh patch   # or minor, major
 ```
 
 Then tag the promoted commit with that version. For exact test-state traceability, use the footer build

--- a/docs/environments/README.md
+++ b/docs/environments/README.md
@@ -62,6 +62,9 @@ make smoke-api env=dev startup_wait=120
 # PowerShell: wait longer for API readiness before smoke checks
 ./scripts/smoke-api.ps1 -Environment dev -StartupWaitSec 120
 
+# Bash: wait longer for API readiness before smoke checks
+bash scripts/smoke-api.sh --environment dev --startup-wait-sec 120
+
 # Validate setup
 make validate-env
 

--- a/scripts/backup-main-postgres.sh
+++ b/scripts/backup-main-postgres.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# backup-main-postgres.sh
+# Bash equivalent of scripts/backup-main-postgres.ps1
+#
+# Creates a timestamped backup of the running main PostgreSQL database.
+# Reads an env file, discovers the postgres container from COMPOSE_PROJECT_NAME,
+# and runs pg_dump inside the container.
+#
+# Usage:
+#   bash scripts/backup-main-postgres.sh [--env-file FILE] [--output-dir DIR] [--format custom|plain]
+#
+# Defaults:
+#   --env-file   .env.main
+#   --output-dir backups/main/postgres
+#   --format     custom
+
+set -euo pipefail
+
+ENV_FILE=".env.main"
+OUTPUT_DIR="backups/main/postgres"
+FORMAT="custom"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env-file)   ENV_FILE="$2"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+    --format)     FORMAT="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; echo "Usage: $0 [--env-file FILE] [--output-dir DIR] [--format custom|plain]"; exit 1 ;;
+  esac
+done
+
+if [[ "$FORMAT" != "custom" && "$FORMAT" != "plain" ]]; then
+  echo "Invalid --format '$FORMAT'. Use 'custom' or 'plain'."
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$WORKSPACE_ROOT"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Env file not found: $ENV_FILE"
+  exit 1
+fi
+
+# Parse env file
+declare -A ENV_MAP
+while IFS= read -r line || [[ -n "$line" ]]; do
+  line="${line%%#*}"
+  line="${line//[$'\r\n']}"
+  [[ -z "$line" ]] && continue
+  [[ "$line" != *=* ]] && continue
+  key="${line%%=*}"
+  val="${line#*=}"
+  key="${key// /}"
+  ENV_MAP["$key"]="$val"
+done < "$ENV_FILE"
+
+COMPOSE_PROJECT="${ENV_MAP[COMPOSE_PROJECT_NAME]:-}"
+DB_USER="${ENV_MAP[POSTGRES_USER]:-}"
+DB_NAME="${ENV_MAP[POSTGRES_DB]:-}"
+
+if [[ -z "$COMPOSE_PROJECT" || -z "$DB_USER" || -z "$DB_NAME" ]]; then
+  echo "Missing one or more required settings in ${ENV_FILE}: COMPOSE_PROJECT_NAME, POSTGRES_USER, POSTGRES_DB"
+  exit 1
+fi
+
+CONTAINER_NAME="${COMPOSE_PROJECT}-postgres"
+
+if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+  echo "Postgres container is not running: $CONTAINER_NAME"
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+EXTENSION="dump"
+[[ "$FORMAT" == "plain" ]] && EXTENSION="sql"
+
+FILE_NAME="${COMPOSE_PROJECT}-${DB_NAME}-${TIMESTAMP}.${EXTENSION}"
+HOST_PATH="${OUTPUT_DIR}/${FILE_NAME}"
+CONTAINER_PATH="/tmp/${FILE_NAME}"
+
+if [[ "$FORMAT" == "custom" ]]; then
+  docker exec "$CONTAINER_NAME" pg_dump -U "$DB_USER" -d "$DB_NAME" -F c -f "$CONTAINER_PATH"
+else
+  docker exec "$CONTAINER_NAME" sh -c "pg_dump -U \"$DB_USER\" -d \"$DB_NAME\" > \"$CONTAINER_PATH\""
+fi
+
+docker cp "${CONTAINER_NAME}:${CONTAINER_PATH}" "$HOST_PATH"
+docker exec "$CONTAINER_NAME" rm -f "$CONTAINER_PATH" || true
+
+SIZE="$(wc -c < "$HOST_PATH")"
+echo "Backup created: $HOST_PATH"
+echo "Size: $SIZE bytes"
+echo ""
+
+if [[ "$FORMAT" == "custom" ]]; then
+  echo "Restore example:"
+  echo "  docker cp $HOST_PATH ${CONTAINER_NAME}:/tmp/${FILE_NAME}"
+  echo "  docker exec -it $CONTAINER_NAME pg_restore -U $DB_USER -d $DB_NAME --clean --if-exists /tmp/${FILE_NAME}"
+else
+  echo "Restore example:"
+  echo "  docker cp $HOST_PATH ${CONTAINER_NAME}:/tmp/${FILE_NAME}"
+  echo "  docker exec -i $CONTAINER_NAME psql -U $DB_USER -d $DB_NAME -f /tmp/${FILE_NAME}"
+fi

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# bump-version.sh
+# Bash equivalent of scripts/bump-version.ps1
+#
+# Bumps the semantic version in VERSION and backend/internal/version/version.go.
+#
+# Usage:
+#   bash scripts/bump-version.sh [patch|minor|major] [--dry-run]
+#
+# Defaults:
+#   part: patch
+
+set -euo pipefail
+
+PART="patch"
+DRY_RUN=false
+VERSION_FILE="VERSION"
+GO_VERSION_FILE="backend/internal/version/version.go"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    patch|minor|major) PART="$1"; shift ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --version-file) VERSION_FILE="$2"; shift 2 ;;
+    --go-version-file) GO_VERSION_FILE="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; echo "Usage: $0 [patch|minor|major] [--dry-run]"; exit 1 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$(dirname "$SCRIPT_DIR")"
+
+if [[ ! -f "$VERSION_FILE" ]]; then
+  echo "Version file not found: $VERSION_FILE"
+  exit 1
+fi
+
+if [[ ! -f "$GO_VERSION_FILE" ]]; then
+  echo "Go version file not found: $GO_VERSION_FILE"
+  exit 1
+fi
+
+CURRENT="$(cat "$VERSION_FILE" | tr -d '[:space:]')"
+
+if [[ ! "$CURRENT" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  echo "Version '$CURRENT' is not valid semantic version text in MAJOR.MINOR.PATCH format."
+  exit 1
+fi
+
+MAJOR="${BASH_REMATCH[1]}"
+MINOR="${BASH_REMATCH[2]}"
+PATCH="${BASH_REMATCH[3]}"
+
+case "$PART" in
+  major) NEXT="$((MAJOR + 1)).0.0" ;;
+  minor) NEXT="${MAJOR}.$((MINOR + 1)).0" ;;
+  patch) NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+esac
+
+if $DRY_RUN; then
+  echo "WhatIf: version would be bumped from $CURRENT to $NEXT ($PART)."
+  exit 0
+fi
+
+# Verify Version constant exists before modifying
+if ! grep -qE 'const Version = "[0-9]+\.[0-9]+\.[0-9]+"' "$GO_VERSION_FILE"; then
+  echo "Failed to locate Version constant in $GO_VERSION_FILE"
+  exit 1
+fi
+
+# Atomic-style update: write temp files, then move both
+VERSION_TMP="${VERSION_FILE}.tmp.$$"
+GO_TMP="${GO_VERSION_FILE}.tmp.$$"
+
+trap 'rm -f "$VERSION_TMP" "$GO_TMP"' EXIT
+
+printf '%s\n' "$NEXT" > "$VERSION_TMP"
+sed -E "s/const Version = \"[0-9]+\.[0-9]+\.[0-9]+\"/const Version = \"$NEXT\"/" "$GO_VERSION_FILE" > "$GO_TMP"
+
+mv "$VERSION_TMP" "$VERSION_FILE"
+mv "$GO_TMP" "$GO_VERSION_FILE"
+
+echo "Version bumped from $CURRENT to $NEXT ($PART)."

--- a/scripts/cleanup-git-refs.sh
+++ b/scripts/cleanup-git-refs.sh
@@ -9,6 +9,7 @@
 #   bash scripts/cleanup-git-refs.sh [--repo-path PATH]
 #       [--namespaces "ns1 ns2 ..."]
 #       [--max-retries N]
+#       [--retry-delay-ms N]
 #       [--prune-empty-parents]
 #       [--workspace-dirs "dir1 dir2 ..."]
 #
@@ -31,6 +32,7 @@ NAMESPACES=(
   "refs/remotes/origin/chore"
 )
 MAX_RETRIES=8
+RETRY_DELAY_MS=250
 PRUNE_EMPTY_PARENTS=false
 WORKSPACE_DIRS=("backups")
 
@@ -39,6 +41,7 @@ while [[ $# -gt 0 ]]; do
     --repo-path)          REPO_PATH="$2"; shift 2 ;;
     --namespaces)         IFS=' ' read -ra NAMESPACES <<< "$2"; shift 2 ;;
     --max-retries)        MAX_RETRIES="$2"; shift 2 ;;
+    --retry-delay-ms)     RETRY_DELAY_MS="$2"; shift 2 ;;
     --prune-empty-parents) PRUNE_EMPTY_PARENTS=true; shift ;;
     --workspace-dirs)     IFS=' ' read -ra WORKSPACE_DIRS <<< "$2"; shift 2 ;;
     *) echo "Unknown argument: $1"; exit 1 ;;
@@ -55,6 +58,9 @@ if [[ -z "$REPO_ROOT" ]]; then
 fi
 
 GIT_DIR="$(git rev-parse --absolute-git-dir 2>/dev/null)"
+
+# Pre-compute sleep delay once (avoids spawning awk on every retry iteration)
+RETRY_DELAY_SEC="$(awk -v delay="$RETRY_DELAY_MS" 'BEGIN {printf "%.3f", delay / 1000}')"
 
 # Normalise a path (resolve trailing slashes, etc.)
 normalize_path() {
@@ -84,7 +90,7 @@ remove_empty_dir_with_retry() {
       return
     fi
 
-    sleep 0.1
+    sleep "$RETRY_DELAY_SEC"
   done
 
   echo "STILL_PRESENT"

--- a/scripts/cleanup-git-refs.sh
+++ b/scripts/cleanup-git-refs.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# cleanup-git-refs.sh
+# Bash equivalent of scripts/cleanup-git-refs.ps1
+#
+# Removes empty stale git ref/log namespace directories from the .git directory
+# and optionally cleans up empty workspace directories (e.g. backups/).
+#
+# Usage:
+#   bash scripts/cleanup-git-refs.sh [--repo-path PATH]
+#       [--namespaces "ns1 ns2 ..."]
+#       [--max-retries N]
+#       [--prune-empty-parents]
+#       [--workspace-dirs "dir1 dir2 ..."]
+#
+# Defaults match the PS1 script defaults.
+
+set -euo pipefail
+
+REPO_PATH="$(pwd)"
+NAMESPACES=(
+  "refs/heads/feat"
+  "logs/refs/heads/feat"
+  "refs/heads/copilot"
+  "logs/refs/heads/copilot"
+  "refs/heads/perf"
+  "logs/refs/heads/perf"
+  "refs/remotes/origin/security"
+  "refs/remotes/origin/fix"
+  "refs/remotes/origin/feat"
+  "refs/remotes/origin/copilot"
+  "refs/remotes/origin/chore"
+)
+MAX_RETRIES=8
+PRUNE_EMPTY_PARENTS=false
+WORKSPACE_DIRS=("backups")
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-path)          REPO_PATH="$2"; shift 2 ;;
+    --namespaces)         IFS=' ' read -ra NAMESPACES <<< "$2"; shift 2 ;;
+    --max-retries)        MAX_RETRIES="$2"; shift 2 ;;
+    --prune-empty-parents) PRUNE_EMPTY_PARENTS=true; shift ;;
+    --workspace-dirs)     IFS=' ' read -ra WORKSPACE_DIRS <<< "$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+cd "$REPO_PATH"
+
+# Resolve git root and git dir
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+if [[ -z "$REPO_ROOT" ]]; then
+  echo "[cleanup-git-refs] No git repository found at $REPO_PATH"
+  exit 1
+fi
+
+GIT_DIR="$(git rev-parse --absolute-git-dir 2>/dev/null)"
+
+# Normalise a path (resolve trailing slashes, etc.)
+normalize_path() {
+  local p="$1"
+  # Remove trailing slash
+  p="${p%/}"
+  echo "$p"
+}
+
+remove_empty_dir_with_retry() {
+  local target="$1"
+
+  if [[ ! -d "$target" ]]; then
+    echo "MISSING"
+    return
+  fi
+
+  local attempt
+  for (( attempt=1; attempt<=MAX_RETRIES; attempt++ )); do
+    if [[ -n "$(ls -A "$target" 2>/dev/null)" ]]; then
+      echo "NOT_EMPTY"
+      return
+    fi
+
+    if rmdir "$target" 2>/dev/null; then
+      echo "REMOVED"
+      return
+    fi
+
+    sleep 0.1
+  done
+
+  echo "STILL_PRESENT"
+}
+
+prune_empty_parents() {
+  local git_root="$1"
+  local rel_path="$2"
+
+  local parent
+  parent="$(dirname "$rel_path")"
+  while [[ "$parent" != "." && "$parent" != "/" ]]; do
+    local full_parent="${git_root}/${parent}"
+    if [[ -d "$full_parent" && -z "$(ls -A "$full_parent" 2>/dev/null)" ]]; then
+      rmdir "$full_parent" 2>/dev/null || true
+    else
+      break
+    fi
+    parent="$(dirname "$parent")"
+  done
+}
+
+STILL_PRESENT_COUNT=0
+echo "[cleanup-git-refs] Processing git ref namespaces..."
+printf '%-50s %s\n' "Namespace" "Result"
+printf '%-50s %s\n' "---------" "------"
+
+for ns in "${NAMESPACES[@]}"; do
+  # Safety: reject absolute paths, parent traversal, and dangerous characters
+  ns_norm="${ns#/}"
+  ns_norm="${ns_norm%/}"
+
+  if [[ "$ns_norm" == *".."* ]] || [[ "$ns_norm" =~ ^/ ]]; then
+    printf '%-50s %s\n' "$ns_norm" "SKIPPED_UNSAFE"
+    continue
+  fi
+
+  target="${GIT_DIR}/${ns_norm}"
+
+  result="$(remove_empty_dir_with_retry "$target")"
+  printf '%-50s %s\n' "$ns_norm" "$result"
+
+  if [[ "$result" == "STILL_PRESENT" ]]; then
+    STILL_PRESENT_COUNT=$((STILL_PRESENT_COUNT + 1))
+  fi
+
+  if $PRUNE_EMPTY_PARENTS && [[ "$result" == "REMOVED" || "$result" == "MISSING" ]]; then
+    prune_empty_parents "$GIT_DIR" "$ns_norm"
+  fi
+done
+
+echo ""
+
+if [[ ${#WORKSPACE_DIRS[@]} -gt 0 ]]; then
+  echo "[cleanup-git-refs] Workspace directory cleanup:"
+  printf '%-40s %s\n' "Directory" "Result"
+  printf '%-40s %s\n' "---------" "------"
+
+  for ws_dir in "${WORKSPACE_DIRS[@]}"; do
+    [[ -z "$ws_dir" ]] && continue
+    ws_norm="${ws_dir#/}"
+    ws_norm="${ws_norm%/}"
+
+    if [[ "$ws_norm" == *".."* ]] || [[ "$ws_norm" =~ ^/ ]]; then
+      printf '%-40s %s\n' "$ws_norm" "SKIPPED_UNSAFE"
+      continue
+    fi
+
+    ws_path="${REPO_ROOT}/${ws_norm}"
+    result="$(remove_empty_dir_with_retry "$ws_path")"
+    printf '%-40s %s\n' "$ws_norm" "$result"
+
+    if [[ "$result" == "STILL_PRESENT" ]]; then
+      STILL_PRESENT_COUNT=$((STILL_PRESENT_COUNT + 1))
+    fi
+  done
+fi
+
+if [[ $STILL_PRESENT_COUNT -gt 0 ]]; then
+  echo ""
+  echo "[cleanup-git-refs] WARNING: Some namespaces are still present (likely locked by sync/indexing)."
+  exit 1
+fi
+
+echo "[cleanup-git-refs] Done."

--- a/scripts/cleanup-stale-translations.sh
+++ b/scripts/cleanup-stale-translations.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# cleanup-stale-translations.sh
+# Bash equivalent of scripts/cleanup-stale-translations.ps1
+#
+# Fetches all translation rows from the admin API, compares them against the
+# locale JSON file, and deletes any rows whose key is no longer present.
+#
+# Requires: curl, jq
+#
+# Usage:
+#   bash scripts/cleanup-stale-translations.sh \
+#     --api-base-url http://localhost:18080 \
+#     --bearer-token <token> \
+#     [--locale-file frontend/public/locales/en/common.json] \
+#     [--what-if]
+
+set -euo pipefail
+
+API_BASE_URL=""
+BEARER_TOKEN=""
+LOCALE_FILE="frontend/public/locales/en/common.json"
+WHAT_IF=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --api-base-url)  API_BASE_URL="$2"; shift 2 ;;
+    --bearer-token)  BEARER_TOKEN="$2"; shift 2 ;;
+    --locale-file)   LOCALE_FILE="$2"; shift 2 ;;
+    --what-if)       WHAT_IF=true; shift ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$API_BASE_URL" ]]; then
+  echo "--api-base-url is required"
+  exit 1
+fi
+
+if [[ ! -f "$LOCALE_FILE" ]]; then
+  echo "Locale file not found: $LOCALE_FILE"
+  exit 1
+fi
+
+# Flatten all leaf keys from the JSON locale file using jq
+# Produces output like: "key.subkey.leaf"
+VALID_KEYS="$(jq -r '[paths(type == "string") | join(".")] | .[]' "$LOCALE_FILE")"
+
+# Paginate through all translation rows
+PAGE_SIZE=200
+OFFSET=0
+PAGE_COUNT=0
+ALL_RECORDS="[]"
+
+while true; do
+  URI="${API_BASE_URL}/api/v1/admin/translations?limit=${PAGE_SIZE}&offset=${OFFSET}"
+
+  RESPONSE="$(curl -sf -H "Authorization: Bearer ${BEARER_TOKEN}" "$URI")"
+  PAGE_RECORDS="$(echo "$RESPONSE" | jq '.records // []')"
+  COUNT="$(echo "$PAGE_RECORDS" | jq 'length')"
+  PAGE_COUNT=$((PAGE_COUNT + 1))
+
+  echo "Fetched translation page $PAGE_COUNT (offset=$OFFSET, rows=$COUNT)"
+
+  if [[ "$COUNT" -eq 0 ]]; then
+    break
+  fi
+
+  ALL_RECORDS="$(echo "${ALL_RECORDS} ${PAGE_RECORDS}" | jq -s '.[0] + .[1]')"
+
+  if [[ "$COUNT" -lt "$PAGE_SIZE" ]]; then
+    break
+  fi
+
+  OFFSET=$((OFFSET + PAGE_SIZE))
+done
+
+echo "Translation pages fetched: $PAGE_COUNT"
+
+TOTAL="$(echo "$ALL_RECORDS" | jq 'length')"
+
+# Find stale rows: those whose translation_key is not in the valid key set
+STALE="$(echo "$ALL_RECORDS" | jq --argjson valid "$(echo "$VALID_KEYS" | jq -Rs '[split("\n")[] | select(length>0)]')" \
+  '[.[] | select(.translation_key as $k | ($valid | index($k)) == null)]')"
+STALE_COUNT="$(echo "$STALE" | jq 'length')"
+
+echo "Total translation rows: $TOTAL"
+echo "Stale rows detected: $STALE_COUNT"
+
+if [[ "$STALE_COUNT" -eq 0 ]]; then
+  echo "No stale translations to delete."
+  exit 0
+fi
+
+if $WHAT_IF; then
+  echo "WhatIf enabled. Stale rows:"
+  echo "$STALE" | jq -r '.[] | "  id=\(.id) key=\(.translation_key) lang=\(.language_code // "?") status=\(.status // "?")'
+  exit 0
+fi
+
+if [[ -z "$BEARER_TOKEN" ]]; then
+  echo "BearerToken is required for delete mode. Use --what-if for dry-run without auth."
+  exit 1
+fi
+
+DELETED=0
+FAILED=0
+
+while IFS= read -r row; do
+  id="$(echo "$row" | jq -r '.id')"
+  key="$(echo "$row" | jq -r '.translation_key')"
+
+  if curl -sf -X DELETE -H "Authorization: Bearer ${BEARER_TOKEN}" \
+       "${API_BASE_URL}/api/v1/translations/${id}" > /dev/null; then
+    DELETED=$((DELETED + 1))
+  else
+    FAILED=$((FAILED + 1))
+    echo "WARNING: Failed to delete translation id=${id} key=${key}" >&2
+  fi
+done < <(echo "$STALE" | jq -c '.[]')
+
+echo "Deleted stale translations: $DELETED"
+echo "Failed deletions: $FAILED"
+
+if [[ "$FAILED" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/migrate-env.sh
+++ b/scripts/migrate-env.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# migrate-env.sh
+# Bash equivalent of scripts/migrate-env.ps1
+#
+# Runs golang-migrate against the target environment's database inside the
+# running backend container.
+#
+# Usage:
+#   bash scripts/migrate-env.sh --environment <main|dev|uat|prod> \
+#       [--direction up|down|force] [--force-version N]
+
+set -euo pipefail
+
+ENVIRONMENT=""
+DIRECTION="up"
+FORCE_VERSION=-1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --environment|-e) ENVIRONMENT="$2"; shift 2 ;;
+    --direction)      DIRECTION="$2"; shift 2 ;;
+    --force-version)  FORCE_VERSION="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; echo "Usage: $0 --environment <main|dev|uat|prod> [--direction up|down|force] [--force-version N]"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$ENVIRONMENT" ]]; then
+  echo "--environment is required. Valid values: main, dev, uat, prod"
+  exit 1
+fi
+
+case "$ENVIRONMENT" in
+  main|dev|uat|prod) ;;
+  *) echo "Invalid environment '$ENVIRONMENT'. Valid values: main, dev, uat, prod"; exit 1 ;;
+esac
+
+case "$DIRECTION" in
+  up|down|force) ;;
+  *) echo "Invalid direction '$DIRECTION'. Valid values: up, down, force"; exit 1 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT"
+
+ENV_FILE=".env.${ENVIRONMENT}"
+COMPOSE_FILE="docker-compose.${ENVIRONMENT}.yml"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing env file: $ENV_FILE"
+  exit 1
+fi
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "Missing compose file: $COMPOSE_FILE"
+  exit 1
+fi
+
+# Parse env file
+declare -A ENV_MAP
+while IFS= read -r line || [[ -n "$line" ]]; do
+  line="${line%%#*}"
+  [[ -z "${line// }" ]] && continue
+  [[ "$line" != *=* ]] && continue
+  key="${line%%=*}"; val="${line#*=}"
+  key="${key// /}"
+  ENV_MAP["$key"]="$val"
+done < "$ENV_FILE"
+
+DB_USER="${ENV_MAP[DATABASE_USER]:-}"
+DB_PASSWORD="${ENV_MAP[DATABASE_PASSWORD]:-}"
+DB_NAME="${ENV_MAP[DATABASE_NAME]:-}"
+
+if [[ -z "$DB_USER" || -z "$DB_PASSWORD" || -z "$DB_NAME" ]]; then
+  echo "DATABASE_USER, DATABASE_PASSWORD, and DATABASE_NAME must be set in $ENV_FILE"
+  exit 1
+fi
+
+DATABASE_URL="postgres://${DB_USER}:${DB_PASSWORD}@postgres:5432/${DB_NAME}?sslmode=disable"
+
+case "$DIRECTION" in
+  up)    CMD_SUFFIX="up" ;;
+  down)  CMD_SUFFIX="down 1" ;;
+  force)
+    if [[ "$FORCE_VERSION" -lt 0 ]]; then
+      echo "--force-version is required when --direction force"
+      exit 1
+    fi
+    CMD_SUFFIX="force $FORCE_VERSION"
+    ;;
+esac
+
+CONTAINER_SCRIPT='rm -f /tmp/migrate /tmp/migrate.tar.gz && apk add --no-cache wget tar >/dev/null && wget --no-check-certificate -q -O /tmp/migrate.tar.gz https://github.com/golang-migrate/migrate/releases/download/v4.18.1/migrate.linux-amd64.tar.gz && tar -xzf /tmp/migrate.tar.gz -C /tmp && chmod +x /tmp/migrate && /tmp/migrate -path /root/migrations -database '"'"''"$DATABASE_URL"''"'"' -verbose '"$CMD_SUFFIX"
+
+echo "Starting dependencies for $ENVIRONMENT..."
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d postgres rabbitmq backend
+
+echo "Running migration '$DIRECTION' for $ENVIRONMENT..."
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" exec -T backend sh -lc "$CONTAINER_SCRIPT"
+
+echo "Done."

--- a/scripts/monitor-lei-sync.sh
+++ b/scripts/monitor-lei-sync.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# monitor-lei-sync.sh
+# Bash equivalent of scripts/monitor-lei-sync.ps1
+#
+# Monitors the LEI full sync progress against the dev environment.
+#
+# Usage:
+#   bash scripts/monitor-lei-sync.sh
+
+set -euo pipefail
+
+echo ""
+echo "=== LEI Full Sync Progress Monitor ==="
+echo "Expected: 3,209,464 records (~9-10 hours processing)"
+echo ""
+
+echo "Download Status:"
+docker logs axiom-dev-backend 2>&1 | grep -E "downloaded successfully|Starting file processing" | tail -1 || true
+
+echo ""
+echo "Database Status:"
+docker exec axiom-dev-postgres psql -U axiom -d axiom_dev -c "
+SELECT
+    COUNT(*) AS current_records,
+    COALESCE((SELECT total_records FROM lei_raw.source_files WHERE file_type='FULL' ORDER BY downloaded_at DESC LIMIT 1), 0) AS expected_records,
+    ROUND((COUNT(*)::numeric / NULLIF((SELECT total_records FROM lei_raw.source_files WHERE file_type='FULL' ORDER BY downloaded_at DESC LIMIT 1), 0)) * 100, 2) AS percent_complete,
+    TO_CHAR(NOW(), 'HH24:MI:SS') AS current_time
+FROM lei_raw.lei_records;
+" 2>&1 || true
+
+echo ""
+echo "Latest Processing Log:"
+docker logs axiom-dev-backend 2>&1 | grep "Processing progress" | tail -1 || true
+
+echo ""
+echo "Source Files:"
+docker exec axiom-dev-postgres psql -U axiom -d axiom_dev -c "
+SELECT
+    file_type,
+    total_records,
+    processed_records,
+    failed_records,
+    processing_status,
+    TO_CHAR(downloaded_at, 'YYYY-MM-DD HH24:MI:SS') AS downloaded
+FROM lei_raw.source_files
+ORDER BY downloaded_at DESC
+LIMIT 3;
+" 2>&1 || true
+
+echo ""
+echo "=== End of Report ==="
+echo "Run this script again to check progress"
+echo ""

--- a/scripts/new-main-test-env.sh
+++ b/scripts/new-main-test-env.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# new-main-test-env.sh
+# Bash equivalent of scripts/new-main-test-env.ps1
+#
+# Creates an isolated .env file for a temporary main-like test stack by copying
+# .env.main and rewriting project/port/database fields.
+#
+# Usage:
+#   bash scripts/new-main-test-env.sh --name <NAME> \
+#       [--source-env-file .env.main] \
+#       [--output-env-file .env.main.<NAME>] \
+#       [--port-offset 100]
+
+set -euo pipefail
+
+NAME=""
+SOURCE_ENV_FILE=".env.main"
+OUTPUT_ENV_FILE=""
+PORT_OFFSET=100
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name|-n)           NAME="$2"; shift 2 ;;
+    --source-env-file)   SOURCE_ENV_FILE="$2"; shift 2 ;;
+    --output-env-file)   OUTPUT_ENV_FILE="$2"; shift 2 ;;
+    --port-offset)       PORT_OFFSET="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; echo "Usage: $0 --name <NAME> [--source-env-file FILE] [--output-env-file FILE] [--port-offset N]"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$NAME" ]]; then
+  echo "--name is required (e.g. --name pr107)"
+  exit 1
+fi
+
+if [[ ! "$NAME" =~ ^[a-zA-Z0-9-]+$ ]]; then
+  echo "--name must contain only alphanumeric characters and hyphens"
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$WORKSPACE_ROOT"
+
+if [[ ! -f "$SOURCE_ENV_FILE" ]]; then
+  echo "Source env file not found: $SOURCE_ENV_FILE"
+  exit 1
+fi
+
+[[ -z "$OUTPUT_ENV_FILE" ]] && OUTPUT_ENV_FILE=".env.main.${NAME}"
+
+COMPOSE_NAME="axiom-main-${NAME}"
+ENV_NAME="main-${NAME}"
+DB_NAME="axiom_main_$(echo "$NAME" | tr '-' '_')"
+LOG_DIR="./log/main-${NAME}"
+
+PORT_KEYS=("POSTGRES_PORT" "RABBITMQ_PORT" "RABBITMQ_MGMT_PORT" "BACKEND_PORT" "FRONTEND_PORT")
+
+# Helper: get value of a key from a file
+get_env_value() {
+  local file="$1" key="$2"
+  grep -E "^\s*${key}=" "$file" | head -1 | cut -d= -f2- | tr -d '[:space:]' || true
+}
+
+# Helper: set or add a key=value in a file (edits in place)
+set_env_value() {
+  local file="$1" key="$2" value="$3"
+  if grep -qE "^\s*${key}=" "$file"; then
+    sed -i "s|^\s*${key}=.*|${key}=${value}|" "$file"
+  else
+    echo "${key}=${value}" >> "$file"
+  fi
+}
+
+# Start from a copy of the source file
+cp "$SOURCE_ENV_FILE" "$OUTPUT_ENV_FILE"
+
+set_env_value "$OUTPUT_ENV_FILE" "COMPOSE_PROJECT_NAME" "$COMPOSE_NAME"
+set_env_value "$OUTPUT_ENV_FILE" "ENVIRONMENT" "$ENV_NAME"
+set_env_value "$OUTPUT_ENV_FILE" "POSTGRES_DB" "$DB_NAME"
+set_env_value "$OUTPUT_ENV_FILE" "DATABASE_NAME" "$DB_NAME"
+set_env_value "$OUTPUT_ENV_FILE" "NEXT_PUBLIC_ENVIRONMENT" "$ENV_NAME"
+set_env_value "$OUTPUT_ENV_FILE" "LOG_MAIN_DIR" "$LOG_DIR"
+
+for key in "${PORT_KEYS[@]}"; do
+  current="$(get_env_value "$OUTPUT_ENV_FILE" "$key")"
+  if [[ -n "$current" && "$current" =~ ^[0-9]+$ ]]; then
+    new_port=$((current + PORT_OFFSET))
+    set_env_value "$OUTPUT_ENV_FILE" "$key" "$new_port"
+  fi
+done
+
+BACKEND_PORT="$(get_env_value "$OUTPUT_ENV_FILE" "BACKEND_PORT")"
+if [[ -n "$BACKEND_PORT" && "$BACKEND_PORT" =~ ^[0-9]+$ ]]; then
+  set_env_value "$OUTPUT_ENV_FILE" "NEXT_PUBLIC_API_URL" "http://localhost:${BACKEND_PORT}"
+fi
+
+echo "Created isolated env file: $OUTPUT_ENV_FILE"
+echo "COMPOSE_PROJECT_NAME=$COMPOSE_NAME"
+echo "POSTGRES_DB=$DB_NAME"
+echo "LOG_MAIN_DIR=$LOG_DIR"
+echo "Port offset applied: +$PORT_OFFSET"
+echo ""
+echo "Use it with:"
+echo "  docker compose --env-file $OUTPUT_ENV_FILE -f docker-compose.main.yml up -d --build"
+echo "  docker compose --env-file $OUTPUT_ENV_FILE -f docker-compose.main.yml down"
+echo ""
+echo "Avoid using '-v' unless you intentionally want to destroy this test stack's data."

--- a/scripts/post-gh-comment-safe.sh
+++ b/scripts/post-gh-comment-safe.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# post-gh-comment-safe.sh
+# Bash equivalent of scripts/post-gh-comment-safe.ps1
+#
+# Posts a GitHub PR or issue comment via the gh CLI, then immediately verifies
+# the stored body matches what was sent. If there is a mismatch it patches the
+# comment in-place and re-verifies.
+#
+# Requires: gh (authenticated), jq
+#
+# Usage:
+#   bash scripts/post-gh-comment-safe.sh \
+#     --repo <owner/repo> \
+#     --target-type pr|issue \
+#     --number <N> \
+#     --body-file <path> \
+#     [--dry-run]
+
+set -euo pipefail
+
+REPO=""
+TARGET_TYPE=""
+NUMBER=""
+BODY_FILE=""
+DRY_RUN=false
+KEEP_TEMP=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)         REPO="$2"; shift 2 ;;
+    --target-type)  TARGET_TYPE="$2"; shift 2 ;;
+    --number)       NUMBER="$2"; shift 2 ;;
+    --body-file)    BODY_FILE="$2"; shift 2 ;;
+    --dry-run)      DRY_RUN=true; shift ;;
+    --keep-temp)    KEEP_TEMP=true; shift ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$REPO" || -z "$TARGET_TYPE" || -z "$NUMBER" || -z "$BODY_FILE" ]]; then
+  echo "Usage: $0 --repo <owner/repo> --target-type pr|issue --number <N> --body-file <path> [--dry-run]"
+  exit 1
+fi
+
+if [[ "$TARGET_TYPE" != "pr" && "$TARGET_TYPE" != "issue" ]]; then
+  echo "--target-type must be 'pr' or 'issue'"
+  exit 1
+fi
+
+if [[ ! -f "$BODY_FILE" ]]; then
+  echo "Body file not found: $BODY_FILE"
+  exit 1
+fi
+
+if $DRY_RUN; then
+  echo "[safe-comment] dry-run target=$TARGET_TYPE number=$NUMBER repo=$REPO"
+  echo "[safe-comment] body_file=$BODY_FILE"
+  exit 0
+fi
+
+VIEWER="$(gh api user --jq .login)"
+if [[ -z "$VIEWER" ]]; then
+  echo "Unable to resolve authenticated GitHub user login via gh api user."
+  exit 1
+fi
+
+EXPECTED="$(cat "$BODY_FILE")"
+
+echo "[safe-comment] posting via --body-file to $TARGET_TYPE #$NUMBER in $REPO"
+
+if [[ "$TARGET_TYPE" == "issue" ]]; then
+  COMMENT_URL="$(gh issue comment "$NUMBER" --repo "$REPO" --body-file "$BODY_FILE" 2>&1 | tail -1 || true)"
+else
+  COMMENT_URL="$(gh pr comment "$NUMBER" --repo "$REPO" --body-file "$BODY_FILE" 2>&1 | tail -1 || true)"
+fi
+
+# Extract comment id from URL (issuecomment-NNNNN)
+COMMENT_ID="$(echo "$COMMENT_URL" | grep -oE 'issuecomment-[0-9]+' | grep -oE '[0-9]+' || true)"
+
+if [[ -z "$COMMENT_ID" ]]; then
+  echo "[safe-comment] comment URL did not include issuecomment id; falling back to latest user comment lookup."
+  COMMENT_ID="$(gh api "repos/$REPO/issues/$NUMBER/comments" --paginate \
+    --jq "[.[] | select(.user.login == \"$VIEWER\")] | last | .id // empty")"
+  if [[ -z "$COMMENT_ID" ]]; then
+    echo "Unable to locate newly posted comment for verification."
+    exit 1
+  fi
+fi
+
+STORED_BODY="$(gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq .body)"
+
+# Normalise line endings for comparison
+EXPECTED_NORM="$(printf '%s' "$EXPECTED" | tr -d '\r' | sed 's/[[:space:]]*$//')"
+STORED_NORM="$(printf '%s' "$STORED_BODY" | tr -d '\r' | sed 's/[[:space:]]*$//')"
+
+if [[ "$STORED_NORM" != "$EXPECTED_NORM" ]]; then
+  echo "[safe-comment] mismatch detected, patching same comment in place..."
+  gh api "repos/$REPO/issues/comments/$COMMENT_ID" --method PATCH -F "body=@$BODY_FILE" > /dev/null
+
+  PATCHED_BODY="$(gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq .body)"
+  PATCHED_NORM="$(printf '%s' "$PATCHED_BODY" | tr -d '\r' | sed 's/[[:space:]]*$//')"
+
+  if [[ "$PATCHED_NORM" != "$EXPECTED_NORM" ]]; then
+    echo "Comment body still mismatched after patch. comment_id=$COMMENT_ID"
+    exit 1
+  fi
+
+  echo "[safe-comment] patch verified. comment_id=$COMMENT_ID"
+else
+  echo "[safe-comment] verified on first post. comment_id=$COMMENT_ID"
+fi
+
+FINAL_URL="${COMMENT_URL:-https://github.com/$REPO/issues/$NUMBER#issuecomment-$COMMENT_ID}"
+echo "$FINAL_URL"

--- a/scripts/post-gh-comment-safe.sh
+++ b/scripts/post-gh-comment-safe.sh
@@ -13,7 +13,7 @@
 #     --repo <owner/repo> \
 #     --target-type pr|issue \
 #     --number <N> \
-#     --body-file <path> \
+#     { --body-file <path> | --body <text> } \
 #     [--dry-run]
 
 set -euo pipefail
@@ -22,8 +22,10 @@ REPO=""
 TARGET_TYPE=""
 NUMBER=""
 BODY_FILE=""
+BODY_TEXT=""
 DRY_RUN=false
 KEEP_TEMP=false
+_TEMP_BODY_FILE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -31,14 +33,34 @@ while [[ $# -gt 0 ]]; do
     --target-type)  TARGET_TYPE="$2"; shift 2 ;;
     --number)       NUMBER="$2"; shift 2 ;;
     --body-file)    BODY_FILE="$2"; shift 2 ;;
+    --body)         BODY_TEXT="$2"; shift 2 ;;
     --dry-run)      DRY_RUN=true; shift ;;
     --keep-temp)    KEEP_TEMP=true; shift ;;
     *) echo "Unknown argument: $1"; exit 1 ;;
   esac
 done
 
+# If --body provided, write to a temp file and treat it as --body-file
+if [[ -n "$BODY_TEXT" && -n "$BODY_FILE" ]]; then
+  echo "Error: --body and --body-file are mutually exclusive."
+  exit 1
+fi
+
+if [[ -n "$BODY_TEXT" && -z "$BODY_FILE" ]]; then
+  _TEMP_BODY_FILE="$(mktemp "${TMPDIR:-/tmp}/post-gh-comment-safe.XXXXXX.md")"
+  printf '%s' "$BODY_TEXT" > "$_TEMP_BODY_FILE"
+  BODY_FILE="$_TEMP_BODY_FILE"
+fi
+
+cleanup_temp() {
+  if [[ -n "$_TEMP_BODY_FILE" && -f "$_TEMP_BODY_FILE" ]] && ! $KEEP_TEMP; then
+    rm -f "$_TEMP_BODY_FILE"
+  fi
+}
+trap cleanup_temp EXIT
+
 if [[ -z "$REPO" || -z "$TARGET_TYPE" || -z "$NUMBER" || -z "$BODY_FILE" ]]; then
-  echo "Usage: $0 --repo <owner/repo> --target-type pr|issue --number <N> --body-file <path> [--dry-run]"
+  echo "Usage: $0 --repo <owner/repo> --target-type pr|issue --number <N> { --body-file <path> | --body <text> } [--dry-run]"
   exit 1
 fi
 

--- a/scripts/setup-branches.ps1
+++ b/scripts/setup-branches.ps1
@@ -48,13 +48,13 @@ function Ok   { param([string]$Msg) Write-Host "OK  $Msg" -ForegroundColor Green
 function Warn { param([string]$Msg) Write-Host "WARN  $Msg" -ForegroundColor Yellow }
 
 function Invoke-Gh {
-    param([string[]]$Args)
+    param([string[]]$GhArgs)
     if ($DryRun) {
-        Write-Host "[dry-run] gh $($Args -join ' ')"
+        Write-Host "[dry-run] gh $($GhArgs -join ' ')"
     } else {
-        & gh @Args
+        & gh @GhArgs
         if ($LASTEXITCODE -ne 0) {
-            throw "gh command failed: gh $($Args -join ' ')"
+            throw "gh command failed: gh $($GhArgs -join ' ')"
         }
     }
 }
@@ -103,7 +103,7 @@ if ($LASTEXITCODE -ne 0) {
 # Step 1 – Create branches (skip if they already exist)
 # ---------------------------------------------------------------------------
 Write-Host "-- Step 1: Create branches -------------------------------------------------"
-$existingBranches = & gh api "repos/$Repo/branches" --jq '.[].name' 2>$null
+$existingBranches = & gh api --paginate "repos/$Repo/branches" --jq '.[].name' 2>$null
 
 foreach ($branch in $Branches) {
     if ($existingBranches -contains $branch) {

--- a/scripts/setup-branches.ps1
+++ b/scripts/setup-branches.ps1
@@ -1,0 +1,203 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+Creates and protects the strategic long-lived branches (dev, uat, prod) for
+the Axiom repository using the GitHub CLI (gh).
+
+.DESCRIPTION
+PowerShell equivalent of scripts/setup-branches.sh.
+
+Prerequisites:
+  - GitHub CLI installed: https://cli.github.com/
+  - Authenticated: gh auth login
+  - Token needs 'repo' and admin:repo_hook scopes (or owner access)
+
+.PARAMETER DryRun
+Print what would happen without making any changes.
+
+.EXAMPLE
+./scripts/setup-branches.ps1
+
+.EXAMPLE
+./scripts/setup-branches.ps1 -DryRun
+
+.NOTES
+See docs/contributing/BRANCHING_STRATEGY.md for full strategy documentation.
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+$SourceBranch = 'main'
+$Branches = @('dev', 'uat', 'prod')
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+function Log  { param([string]$Msg) Write-Host "  $Msg" }
+function Info { param([string]$Msg) Write-Host "->  $Msg" }
+function Ok   { param([string]$Msg) Write-Host "OK  $Msg" -ForegroundColor Green }
+function Warn { param([string]$Msg) Write-Host "WARN  $Msg" -ForegroundColor Yellow }
+
+function Invoke-Gh {
+    param([string[]]$Args)
+    if ($DryRun) {
+        Write-Host "[dry-run] gh $($Args -join ' ')"
+    } else {
+        & gh @Args
+        if ($LASTEXITCODE -ne 0) {
+            throw "gh command failed: gh $($Args -join ' ')"
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Detect repository
+# ---------------------------------------------------------------------------
+$Repo = $env:GITHUB_REPOSITORY
+
+if ([string]::IsNullOrWhiteSpace($Repo)) {
+    try {
+        $remoteUrl = git remote get-url origin 2>$null
+        if ($remoteUrl -match 'github\.com[:/]([^/]+/[^/\.]+)') {
+            $Repo = $Matches[1] -replace '\.git$', ''
+        }
+    } catch {
+        # ignore
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($Repo)) {
+    Write-Error "Could not detect repository. Set GITHUB_REPOSITORY (owner/repo) or run from inside the repo."
+    exit 1
+}
+
+Info "Repository : $Repo"
+Info "Source     : $SourceBranch"
+Info "Dry run    : $DryRun"
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Error "GitHub CLI (gh) is not installed. Install it from https://cli.github.com/"
+    exit 1
+}
+
+& gh auth status 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Not authenticated with GitHub CLI. Run: gh auth login"
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Step 1 – Create branches (skip if they already exist)
+# ---------------------------------------------------------------------------
+Write-Host "-- Step 1: Create branches -------------------------------------------------"
+$existingBranches = & gh api "repos/$Repo/branches" --jq '.[].name' 2>$null
+
+foreach ($branch in $Branches) {
+    if ($existingBranches -contains $branch) {
+        Warn "Branch '$branch' already exists -- skipping creation."
+    } else {
+        Info "Creating branch '$branch' from '$SourceBranch' ..."
+        if ($DryRun) {
+            Write-Host "[dry-run] gh api --method POST repos/$Repo/git/refs -f ref=refs/heads/$branch -f sha=<HEAD sha of $SourceBranch>"
+        } else {
+            $sourceSha = & gh api "repos/$Repo/branches/$SourceBranch" --jq '.commit.sha'
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($sourceSha)) {
+                Write-Error "Failed to get SHA for '$SourceBranch'. Check REPO and token scopes."
+                exit 1
+            }
+            & gh api `
+                --method POST `
+                -H "Accept: application/vnd.github+json" `
+                "repos/$Repo/git/refs" `
+                -f "ref=refs/heads/$branch" `
+                -f "sha=$sourceSha"
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error "Failed to create branch '$branch'."
+                exit 1
+            }
+            Ok "Created '$branch'."
+        }
+    }
+}
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# Step 2 – Apply branch protection rules
+# ---------------------------------------------------------------------------
+Write-Host "-- Step 2: Apply branch protection -----------------------------------------"
+
+function Set-BranchProtection {
+    param([string]$Branch, [int]$RequiredApprovals)
+
+    Info "Protecting '$Branch' (required approvals: $RequiredApprovals) ..."
+
+    $body = @{
+        required_status_checks       = @{ strict = $true; contexts = @() }
+        enforce_admins               = $true
+        required_pull_request_reviews = @{
+            dismiss_stale_reviews         = $true
+            require_code_owner_reviews    = $false
+            required_approving_review_count = $RequiredApprovals
+        }
+        restrictions                 = $null
+        allow_force_pushes           = $false
+        allow_deletions              = $false
+        required_conversation_resolution = $true
+    } | ConvertTo-Json -Depth 10
+
+    if ($DryRun) {
+        Write-Host "[dry-run] gh api --method PUT repos/$Repo/branches/$Branch/protection --input <json>"
+    } else {
+        $tmpFile = [System.IO.Path]::GetTempFileName()
+        try {
+            Set-Content -Path $tmpFile -Value $body -Encoding utf8
+            & gh api `
+                --method PUT `
+                -H "Accept: application/vnd.github+json" `
+                "repos/$Repo/branches/$Branch/protection" `
+                --input $tmpFile
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error "Failed to apply protection to '$Branch'. Check token scopes (repo + admin:repo_hook)."
+                exit 1
+            }
+        } finally {
+            Remove-Item $tmpFile -ErrorAction SilentlyContinue
+        }
+        Ok "Protected '$Branch'."
+    }
+}
+
+Set-BranchProtection 'main' 1
+Set-BranchProtection 'dev'  1
+Set-BranchProtection 'uat'  1
+Set-BranchProtection 'prod' 2
+
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+Write-Host "============================================================"
+Ok "Branch setup complete."
+Write-Host ""
+Write-Host "Next steps:"
+Write-Host "  1. Verify branches in GitHub -> Code -> Branches."
+Write-Host "  2. Confirm protection rules in GitHub -> Settings -> Branches."
+Write-Host "  3. Attach required CI status checks once workflows are named."
+Write-Host "     GitHub -> Settings -> Branches -> edit rule -> Status checks."
+Write-Host ""
+Write-Host "  See docs/contributing/BRANCHING_STRATEGY.md for the full guide."
+Write-Host "============================================================"

--- a/scripts/smoke-api.sh
+++ b/scripts/smoke-api.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# smoke-api.sh
+# Bash equivalent of scripts/smoke-api.ps1
+#
+# Runs API smoke tests for main, dev, UAT, and/or prod environments.
+#
+# Checks per environment:
+#   - GET /health returns HTTP 200 and body contains "healthy"
+#   - GET /version returns HTTP 200
+#   - GET /api/v1/entities without auth returns HTTP 401
+#   - GET /api/v1/entities with a generated HS256 JWT is accepted (not 401/403)
+#   - (optional) POST /api/v1/auth/login returns HTTP 200 (informational)
+#
+# Requires: curl, openssl (or python3 for HMAC), jq
+#
+# Usage:
+#   bash scripts/smoke-api.sh [--environment main|dev|uat|prod|all]
+#       [--timeout-sec 20] [--startup-wait-sec 90] [--check-login]
+
+set -euo pipefail
+
+ENVIRONMENT="all"
+TIMEOUT_SEC=20
+STARTUP_WAIT_SEC=90
+CHECK_LOGIN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --environment|-e) ENVIRONMENT="$2"; shift 2 ;;
+    --timeout-sec)    TIMEOUT_SEC="$2"; shift 2 ;;
+    --startup-wait-sec) STARTUP_WAIT_SEC="$2"; shift 2 ;;
+    --check-login)    CHECK_LOGIN=true; shift ;;
+    *) echo "Unknown argument: $1"; echo "Usage: $0 [--environment main|dev|uat|prod|all] [--timeout-sec N] [--startup-wait-sec N] [--check-login]"; exit 1 ;;
+  esac
+done
+
+case "$ENVIRONMENT" in
+  main|dev|uat|prod|all) ;;
+  *) echo "Invalid environment '$ENVIRONMENT'. Valid values: main, dev, uat, prod, all"; exit 1 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$WORKSPACE_ROOT"
+
+# ---------------------------------------------------------------------------
+# JWT generation: pure bash using python3 (available on all CI runners)
+# ---------------------------------------------------------------------------
+make_hs256_jwt() {
+  local secret="$1" user_id="$2" email="$3"
+
+  python3 - "$secret" "$user_id" "$email" <<'PYEOF'
+import sys, base64, json, hmac, hashlib
+
+secret, user_id, email = sys.argv[1], sys.argv[2], sys.argv[3]
+
+def b64url(data):
+    return base64.urlsafe_b64encode(data).rstrip(b'=').decode()
+
+header  = b64url(json.dumps({"alg":"HS256","typ":"JWT"}, separators=(',',':')).encode())
+payload = b64url(json.dumps({"user_id": user_id, "email": email}, separators=(',',':')).encode())
+unsigned = f"{header}.{payload}"
+sig = b64url(hmac.new(secret.encode(), unsigned.encode(), hashlib.sha256).digest())
+print(f"{unsigned}.{sig}")
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+parse_env_value() {
+  local file="$1" key="$2"
+  grep -E "^\s*${key}=" "$file" | head -1 | cut -d= -f2- | tr -d '[:space:]' || true
+}
+
+http_get() {
+  local url="$1" timeout="$2"
+  shift 2
+  curl -so /dev/null -w "%{http_code}" --max-time "$timeout" "$@" "$url" 2>/dev/null || true
+}
+
+wait_api_ready() {
+  local base_url="$1" max_sec="$2"
+  [[ "$max_sec" -le 0 ]] && return 0
+
+  local deadline=$((SECONDS + max_sec))
+  while [[ $SECONDS -lt $deadline ]]; do
+    local code
+    code="$(http_get "${base_url}/health" 5)"
+    if [[ "$code" == "200" ]]; then
+      return 0
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Build target list
+# ---------------------------------------------------------------------------
+if [[ "$ENVIRONMENT" == "all" ]]; then
+  TARGETS=("main" "dev" "uat" "prod")
+else
+  TARGETS=("$ENVIRONMENT")
+fi
+
+FAILED=0
+
+echo ""
+echo "=== Axiom API Smoke Test ==="
+echo "Workspace: $WORKSPACE_ROOT"
+echo "Targets: ${TARGETS[*]}"
+echo "Timeout: ${TIMEOUT_SEC}s"
+echo "Startup wait: ${STARTUP_WAIT_SEC}s max"
+echo ""
+
+declare -A RESULT_HEALTH RESULT_VERSION RESULT_UNAUTH RESULT_AUTH RESULT_LOGIN RESULT_PASS
+
+for env_name in "${TARGETS[@]}"; do
+  env_file="${WORKSPACE_ROOT}/.env.${env_name}"
+  backend_port="$(parse_env_value "$env_file" "BACKEND_PORT")"
+  jwt_secret="$(parse_env_value "$env_file" "JWT_SECRET")"
+
+  if [[ -z "$backend_port" ]]; then
+    echo "BACKEND_PORT missing in $env_file"
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+  if [[ -z "$jwt_secret" ]]; then
+    echo "JWT_SECRET missing in $env_file"
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+
+  BASE_URL="http://localhost:${backend_port}"
+  echo "[${env_name^^}] Base URL: $BASE_URL"
+
+  if ! wait_api_ready "$BASE_URL" "$STARTUP_WAIT_SEC"; then
+    echo "  readiness=TIMEOUT after ${STARTUP_WAIT_SEC}s; continuing with checks"
+  fi
+
+  health_code="$(http_get "${BASE_URL}/health" "$TIMEOUT_SEC")"
+  health_body="$(curl -sf --max-time "$TIMEOUT_SEC" "${BASE_URL}/health" 2>/dev/null || true)"
+  version_code="$(http_get "${BASE_URL}/version" "$TIMEOUT_SEC")"
+  unauth_code="$(http_get "${BASE_URL}/api/v1/entities?limit=1&offset=0" "$TIMEOUT_SEC")"
+
+  jwt="$(make_hs256_jwt "$jwt_secret" "00000000-0000-0000-0000-000000000001" "smoke@test.local")"
+  auth_code="$(http_get "${BASE_URL}/api/v1/entities?limit=1&offset=0" "$TIMEOUT_SEC" -H "Authorization: Bearer ${jwt}")"
+
+  login_code=""
+  if $CHECK_LOGIN; then
+    login_code="$(curl -so /dev/null -w "%{http_code}" --max-time "$TIMEOUT_SEC" \
+      -X POST -H "Content-Type: application/json" -d '{"email":"x","password":"y"}' \
+      "${BASE_URL}/api/v1/auth/login" 2>/dev/null || true)"
+  fi
+
+  health_ok=false
+  [[ "$health_code" == "200" && "$health_body" == *"healthy"* ]] && health_ok=true
+  version_ok=false; [[ "$version_code" == "200" ]] && version_ok=true
+  unauth_ok=false; [[ "$unauth_code" == "401" ]] && unauth_ok=true
+  auth_accepted=false
+  [[ -n "$auth_code" && "$auth_code" != "401" && "$auth_code" != "403" ]] && auth_accepted=true
+
+  all_passed=false
+  $health_ok && $version_ok && $unauth_ok && $auth_accepted && all_passed=true
+
+  RESULT_HEALTH[$env_name]="$health_code"
+  RESULT_VERSION[$env_name]="$version_code"
+  RESULT_UNAUTH[$env_name]="$unauth_code"
+  RESULT_AUTH[$env_name]="$auth_code"
+  RESULT_LOGIN[$env_name]="${login_code:-n/a}"
+  RESULT_PASS[$env_name]="$($all_passed && echo PASS || echo FAIL)"
+
+  $all_passed || FAILED=$((FAILED + 1))
+
+  echo "  health=${health_code} version=${version_code} unauth=${unauth_code} auth=${auth_code}"
+  $CHECK_LOGIN && echo "  login=${login_code} (informational)"
+  echo "  result=$($all_passed && echo PASS || echo FAIL)"
+  echo ""
+done
+
+echo "=== Summary ==="
+printf '%-10s %-8s %-8s %-8s %-8s %-8s %s\n' "Env" "Health" "Version" "Unauth" "Auth" "Login" "Passed"
+for env_name in "${TARGETS[@]}"; do
+  printf '%-10s %-8s %-8s %-8s %-8s %-8s %s\n' \
+    "$env_name" \
+    "${RESULT_HEALTH[$env_name]:-?}" \
+    "${RESULT_VERSION[$env_name]:-?}" \
+    "${RESULT_UNAUTH[$env_name]:-?}" \
+    "${RESULT_AUTH[$env_name]:-?}" \
+    "${RESULT_LOGIN[$env_name]:-?}" \
+    "${RESULT_PASS[$env_name]:-?}"
+done
+
+if [[ "$FAILED" -gt 0 ]]; then
+  echo ""
+  echo "One or more environments failed smoke checks."
+  exit 1
+fi
+
+echo ""
+echo "All smoke checks passed."
+exit 0

--- a/scripts/smoke-ssi.sh
+++ b/scripts/smoke-ssi.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# smoke-ssi.sh
+# Bash equivalent of scripts/smoke-ssi.ps1
+#
+# Runs SSI smoke tests against the specified environment.
+# Optionally seeds temporary rows before the test and cleans them up after.
+#
+# Requires: curl, jq, python3 (for JWT), docker
+#
+# Usage:
+#   bash scripts/smoke-ssi.sh [--environment main|dev|uat|prod]
+#       [--api-base-url URL]
+#       [--seed-smoke-data]
+#       [--cleanup-smoke-data]
+#       [--timeout-sec 25]
+
+set -euo pipefail
+
+ENVIRONMENT="dev"
+API_BASE_URL=""
+SEED_SMOKE_DATA=false
+CLEANUP_SMOKE_DATA=false
+TIMEOUT_SEC=25
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --environment|-e)    ENVIRONMENT="$2"; shift 2 ;;
+    --api-base-url)      API_BASE_URL="$2"; shift 2 ;;
+    --seed-smoke-data)   SEED_SMOKE_DATA=true; shift ;;
+    --cleanup-smoke-data) CLEANUP_SMOKE_DATA=true; shift ;;
+    --timeout-sec)       TIMEOUT_SEC="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+case "$ENVIRONMENT" in
+  main|dev|uat|prod) ;;
+  *) echo "Invalid environment '$ENVIRONMENT'. Valid values: main, dev, uat, prod"; exit 1 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$(dirname "$SCRIPT_DIR")"
+
+# ---------------------------------------------------------------------------
+# Environment config
+# ---------------------------------------------------------------------------
+case "$ENVIRONMENT" in
+  main) ENV_FILE=".env.main"; COMPOSE_FILE="docker-compose.main.yml"; DEFAULT_URL="http://localhost:48080"; DATABASE="axiom_main" ;;
+  dev)  ENV_FILE=".env.dev";  COMPOSE_FILE="docker-compose.dev.yml";  DEFAULT_URL="http://localhost:18080"; DATABASE="axiom_dev"  ;;
+  uat)  ENV_FILE=".env.uat";  COMPOSE_FILE="docker-compose.uat.yml";  DEFAULT_URL="http://localhost:28080"; DATABASE="axiom_uat"  ;;
+  prod) ENV_FILE=".env.prod"; COMPOSE_FILE="docker-compose.prod.yml"; DEFAULT_URL="http://localhost:38080"; DATABASE="axiom_prod" ;;
+esac
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Environment file not found: $ENV_FILE"
+  exit 1
+fi
+
+RESOLVED_URL="${API_BASE_URL:-$DEFAULT_URL}"
+RESOLVED_URL="${RESOLVED_URL%/}"
+
+# ---------------------------------------------------------------------------
+# JWT generation via python3 (mirrors PS1 implementation)
+# ---------------------------------------------------------------------------
+make_jwt() {
+  local secret="$1"
+  python3 - "$secret" <<'PYEOF'
+import sys, base64, json, hmac, hashlib
+
+secret = sys.argv[1]
+header_json  = '{"alg":"HS256","typ":"JWT"}'
+payload_json = '{"user_id":"00000000-0000-0000-0000-000000000001","email":"smoke@test.local"}'
+
+def b64url(data):
+    return base64.urlsafe_b64encode(data).rstrip(b'=').decode()
+
+h = b64url(header_json.encode())
+p = b64url(payload_json.encode())
+unsigned = f"{h}.{p}"
+sig = b64url(hmac.new(secret.encode(), unsigned.encode(), hashlib.sha256).digest())
+print(f"{unsigned}.{sig}")
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# SQL helper
+# ---------------------------------------------------------------------------
+invoke_sql() {
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" exec -T postgres \
+    psql -U axiom -d "$DATABASE" -c "$1" > /dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Resolve JWT secret
+# ---------------------------------------------------------------------------
+SECRET_LINE="$(grep -E '^JWT_SECRET=' "$ENV_FILE" | head -1 || true)"
+if [[ -z "$SECRET_LINE" ]]; then
+  echo "JWT_SECRET missing in $ENV_FILE"
+  exit 1
+fi
+JWT_SECRET="${SECRET_LINE#JWT_SECRET=}"
+JWT_SECRET="${JWT_SECRET// /}"
+
+TOKEN="$(make_jwt "$JWT_SECRET")"
+
+# ---------------------------------------------------------------------------
+# Optional seed
+# ---------------------------------------------------------------------------
+if $SEED_SMOKE_DATA; then
+  echo "[SSI Smoke] Seeding 2 temporary rows..."
+  invoke_sql "DELETE FROM ssis WHERE beneficiary_name IN ('SSI Smoke CP 1','SSI Smoke CP 2');"
+  invoke_sql "INSERT INTO ssis (beneficiary_name, beneficiary_account, beneficiary_bank, beneficiary_bank_bic, intermediary_bank, intermediary_bank_bic, settlement_type, active, valid_from) VALUES ('SSI Smoke CP 1','GB29NWBK60161331926819','Smoke Bank UK','NWBKGB2L','Intermediary One','IRVTUS3N','DAP',TRUE,NOW()),('SSI Smoke CP 2','SE4550000000058398257466','Smoke Bank SE','ESSESESS','Intermediary Two','CHASUS33','FOP',TRUE,NOW());"
+fi
+
+REQUIRED_FIELDS=("id" "ssi_reference" "counterparty_name" "account_name" "country_code" "currency" "bic" "iban" "settlement_method" "status" "updated_at")
+
+# ---------------------------------------------------------------------------
+# Call SSI endpoint
+# ---------------------------------------------------------------------------
+echo "[SSI Smoke] Calling ${RESOLVED_URL}/api/v1/ssis ..."
+
+RESPONSE="$(curl -s -w "\n%{http_code}" --max-time "$TIMEOUT_SEC" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Accept: application/json" \
+  "${RESOLVED_URL}/api/v1/ssis?limit=500&offset=0")"
+
+HTTP_CODE="$(echo "$RESPONSE" | tail -1)"
+BODY="$(echo "$RESPONSE" | head -n -1)"
+
+RECORDS_COUNT="$(echo "$BODY" | jq '[.[] // empty] | length' 2>/dev/null || echo 0)"
+
+# Check missing fields against first record
+MISSING_FIELDS=()
+if [[ "$RECORDS_COUNT" -gt 0 ]]; then
+  for field in "${REQUIRED_FIELDS[@]}"; do
+    if ! echo "$BODY" | jq -e ".[0] | has(\"$field\")" > /dev/null 2>&1; then
+      MISSING_FIELDS+=("$field")
+    fi
+  done
+fi
+
+SMOKE_ROWS_COUNT="$(echo "$BODY" | jq '[.[] | select(.counterparty_name == "SSI Smoke CP 1" or .counterparty_name == "SSI Smoke CP 2")] | length' 2>/dev/null || echo 0)"
+BGC_MATCHES="$(echo "$BODY" | jq '[.[] | select((.counterparty_name // "" | test("BGC")) or (.account_name // "" | test("BGC")))] | length' 2>/dev/null || echo 0)"
+
+MISSING_FIELDS_STR="none"
+[[ ${#MISSING_FIELDS[@]} -gt 0 ]] && MISSING_FIELDS_STR="$(IFS=','; echo "${MISSING_FIELDS[*]}")"
+
+echo "[SSI Smoke] http_status=${HTTP_CODE}"
+echo "[SSI Smoke] records=${RECORDS_COUNT}"
+echo "[SSI Smoke] missing_fields=${MISSING_FIELDS_STR}"
+echo "[SSI Smoke] smoke_rows=${SMOKE_ROWS_COUNT}"
+echo "[SSI Smoke] bgc_matches=${BGC_MATCHES}"
+
+# ---------------------------------------------------------------------------
+# Optional cleanup
+# ---------------------------------------------------------------------------
+if $CLEANUP_SMOKE_DATA; then
+  echo "[SSI Smoke] Cleaning temporary rows..."
+  invoke_sql "DELETE FROM ssis WHERE beneficiary_name IN ('SSI Smoke CP 1','SSI Smoke CP 2');"
+fi
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+IS_PASS=true
+[[ "$HTTP_CODE" != "200" ]] && IS_PASS=false
+[[ ${#MISSING_FIELDS[@]} -gt 0 ]] && IS_PASS=false
+[[ "$BGC_MATCHES" -gt 0 ]] && IS_PASS=false
+
+if $IS_PASS; then
+  echo "[SSI Smoke] result=PASS"
+  exit 0
+else
+  echo "[SSI Smoke] result=FAIL"
+  exit 1
+fi

--- a/scripts/validate-calm.ps1
+++ b/scripts/validate-calm.ps1
@@ -1,0 +1,56 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+Validates all CALM architecture model files found under docs/architecture-as-code/models/.
+
+.DESCRIPTION
+Runs `npx @finos/calm-cli validate` against every *.architecture.json file.
+Exits 1 (or warns and exits 0 with --warn) if any model fails validation.
+
+.PARAMETER Warn
+Treat validation failures as warnings and exit 0 instead of failing.
+
+.EXAMPLE
+./scripts/validate-calm.ps1
+
+.EXAMPLE
+./scripts/validate-calm.ps1 -Warn
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Warn
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ModelGlob = 'docs/architecture-as-code/models/*.architecture.json'
+$models = Get-ChildItem -Path $ModelGlob -ErrorAction SilentlyContinue
+
+if ($null -eq $models -or $models.Count -eq 0) {
+    Write-Host "No CALM model files found at $ModelGlob"
+    exit 0
+}
+
+$errors = 0
+
+foreach ($model in $models) {
+    Write-Host "Validating CALM model: $($model.FullName)"
+    & npx --yes @finos/calm-cli validate -a "$($model.FullName)"
+    if ($LASTEXITCODE -ne 0) {
+        $errors++
+    }
+}
+
+if ($errors -gt 0) {
+    if ($Warn) {
+        Write-Host "WARN: CALM validation reported $errors failing model(s); continuing in warn mode."
+        exit 0
+    }
+
+    Write-Host "ERROR: CALM validation failed for $errors model(s)."
+    exit 1
+}
+
+Write-Host "CALM validation passed for all model files."

--- a/scripts/validate-calm.ps1
+++ b/scripts/validate-calm.ps1
@@ -5,7 +5,7 @@ Validates all CALM architecture model files found under docs/architecture-as-cod
 
 .DESCRIPTION
 Runs `npx @finos/calm-cli validate` against every *.architecture.json file.
-Exits 1 (or warns and exits 0 with --warn) if any model fails validation.
+Exits 1 (or warns and exits 0 with -Warn) if any model fails validation.
 
 .PARAMETER Warn
 Treat validation failures as warnings and exit 0 instead of failing.

--- a/scripts/validate-multi-env.ps1
+++ b/scripts/validate-multi-env.ps1
@@ -1,0 +1,104 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+Validates the multi-environment setup for Axiom.
+
+.DESCRIPTION
+Checks configuration files, docker-compose validity, port assignments, and
+Makefile targets across all four environments (main, dev, uat, prod).
+
+.EXAMPLE
+./scripts/validate-multi-env.ps1
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Write-Host "=========================================="
+Write-Host "Axiom Multi-Environment Validation"
+Write-Host "=========================================="
+Write-Host ""
+
+function Write-Success { param([string]$Msg) Write-Host "  [OK] $Msg" -ForegroundColor Green }
+function Write-Fail    { param([string]$Msg) Write-Host "  [FAIL] $Msg" -ForegroundColor Red }
+
+# ---------------------------------------------------------------------------
+# 1. Required configuration files
+# ---------------------------------------------------------------------------
+Write-Host "1. Checking configuration files..."
+$files = @('.env.main', '.env.dev', '.env.uat', '.env.prod',
+           'docker-compose.main.yml', 'docker-compose.dev.yml',
+           'docker-compose.uat.yml', 'docker-compose.prod.yml')
+
+foreach ($file in $files) {
+    if (Test-Path $file) {
+        Write-Success "$file exists"
+    } else {
+        Write-Fail "$file missing"
+        exit 1
+    }
+}
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# 2. docker compose config validation
+# ---------------------------------------------------------------------------
+Write-Host "2. Validating docker-compose configurations..."
+$envs = @('main', 'dev', 'uat', 'prod')
+foreach ($env in $envs) {
+    $null = & docker compose --env-file ".env.$env" -f "docker-compose.$env.yml" config 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        Write-Success "docker-compose.$env.yml is valid"
+    } else {
+        Write-Fail "docker-compose.$env.yml has errors"
+        exit 1
+    }
+}
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# 3. Port configuration checks
+# ---------------------------------------------------------------------------
+Write-Host "3. Validating port configurations..."
+
+function Assert-Ports {
+    param([string]$EnvFile, [string]$Label, [string]$Backend, [string]$Frontend, [string]$Postgres)
+
+    $content = Get-Content $EnvFile -Raw
+    if ($content -match "BACKEND_PORT=$Backend" -and
+        $content -match "FRONTEND_PORT=$Frontend" -and
+        $content -match "POSTGRES_PORT=$Postgres") {
+        Write-Success "$Label ports correctly configured"
+    } else {
+        Write-Fail "$Label ports incorrectly configured"
+        exit 1
+    }
+}
+
+Assert-Ports '.env.main' 'Main branch (prefix: 4)'  '48080' '43000' '45432'
+Assert-Ports '.env.dev'  'Development (prefix: 1)'  '18080' '13000' '15432'
+Assert-Ports '.env.uat'  'UAT (prefix: 2)'          '28080' '23000' '25432'
+Assert-Ports '.env.prod' 'Production (prefix: 3)'   '38080' '33000' '35432'
+
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# 4. Makefile targets
+# ---------------------------------------------------------------------------
+Write-Host "4. Validating Makefile targets..."
+$makefileContent = Get-Content Makefile -Raw
+$targets = @('docker-main-up', 'docker-dev-up', 'docker-uat-up', 'docker-prod-up', 'docker-all-up')
+foreach ($target in $targets) {
+    if ($makefileContent -match "(?m)^${target}:") {
+        Write-Success "Makefile target '$target' exists"
+    } else {
+        Write-Fail "Makefile target '$target' missing"
+        exit 1
+    }
+}
+Write-Host ""
+
+Write-Host "=========================================="
+Write-Host "All validation checks passed!" -ForegroundColor Green
+Write-Host "=========================================="
+Write-Host ""


### PR DESCRIPTION
## Summary

Introduces a mandatory shell-parity instruction and implements **full bash/PowerShell
parity** for all scripts in `scripts/` — every script now has both a `.sh` and a `.ps1` counterpart.

### What changed

#### Instruction

| File | Change |
|------|--------|
| `.github/instructions/script-shell-parity.instructions.md` | **New** — mandates both `.sh` and `.ps1` counterparts for every `scripts/` file; documents intentional PS1-only exceptions (git-hook utilities) |

#### New PS1 counterparts (for existing bash-only scripts)

| Script | Counterpart added |
|--------|-------------------|
| `validate-calm.sh` | `validate-calm.ps1` |
| `validate-multi-env.sh` | `validate-multi-env.ps1` |
| `setup-branches.sh` | `setup-branches.ps1` |

#### New bash counterparts (for existing PS1-only scripts)

| Script | Counterpart added |
|--------|-------------------|
| `backup-main-postgres.ps1` | `backup-main-postgres.sh` |
| `bump-version.ps1` | `bump-version.sh` |
| `cleanup-git-refs.ps1` | `cleanup-git-refs.sh` |
| `cleanup-stale-translations.ps1` | `cleanup-stale-translations.sh` |
| `migrate-env.ps1` | `migrate-env.sh` |
| `monitor-lei-sync.ps1` | `monitor-lei-sync.sh` |
| `new-main-test-env.ps1` | `new-main-test-env.sh` |
| `post-gh-comment-safe.ps1` | `post-gh-comment-safe.sh` |
| `smoke-api.ps1` | `smoke-api.sh` |
| `smoke-ssi.ps1` | `smoke-ssi.sh` |

> `sort-ra-urls.ps1` and `sort-vscode-settings.ps1` remain intentionally PS1-only (git hook utilities
> that explicitly require `pwsh`) and are documented as exceptions in the instruction file.

### JWT generation in bash scripts

`smoke-api.sh` and `smoke-ssi.sh` generate HS256 JWTs via an inline `python3` snippet (no external
JWT library required). `python3` is available on all standard CI runners (Ubuntu, macOS) and in the
project's dev containers.

Closes #527
