### PR TITLE
perf: add composite index for status+update_date filter on lei_records (15x improvement)

### DIFF
--- a/backend/migrations/000072_add_lei_records_status_update_index.down.sql
+++ b/backend/migrations/000072_add_lei_records_status_update_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS lei_raw.idx_lei_records_status_last_update_active;

--- a/backend/migrations/000072_add_lei_records_status_update_index.up.sql
+++ b/backend/migrations/000072_add_lei_records_status_update_index.up.sql
@@ -1,0 +1,19 @@
+-- Optimise the entity_status + ORDER BY last_update_date query pattern on lei_records:
+--   WHERE entity_status = ? AND deleted_at IS NULL ORDER BY last_update_date DESC LIMIT n
+--
+-- Without this index the planner uses idx_lei_records_last_update_date (last_update_date)
+-- which scans all rows in reverse date order, then filters on status post-scan.
+-- For INACTIVE status (238k rows) the planner had to discard 4 652 rows to find 51 results.
+--
+-- The composite partial index (entity_status, last_update_date) WHERE deleted_at IS NULL:
+--   1. Narrows the scan to the requested status immediately (first key column)
+--   2. Returns rows pre-sorted by last_update_date DESC (second key column), no sort needed
+--   3. The partial predicate excludes soft-deleted rows from the index entirely
+--
+-- Result: LIMIT 51 reads exactly 51 index entries and 51 heap pages, not 4 700+.
+
+CREATE INDEX IF NOT EXISTS idx_lei_records_status_last_update_active
+ON lei_raw.lei_records (entity_status, last_update_date DESC)
+WHERE (deleted_at IS NULL);
+
+ANALYZE lei_raw.lei_records;


### PR DESCRIPTION
## Summary

Fixes #530

Entity-status filter queries on LEI Records list page taking ~533ms.

## Root cause

`EXPLAIN (ANALYZE, BUFFERS)` on `axiom_main` (6.8M rows):

```
Limit (actual time=1.293..9.663 rows=51 loops=1)
  -> Index Scan Backward using idx_lei_records_last_update_date on lei_records
       Filter: (deleted_at IS NULL AND entity_status = 'INACTIVE')
       Rows Removed by Filter: 4652
       Buffers: shared hit=4733
Planning Time: 474 ms   Execution Time: 9.8 ms
```

**Planning overhead** (474ms) dominates. The planner uses `idx_lei_records_last_update_date` and filters 
on status post-scan, forcing it to discard 4652 non-INACTIVE rows before finding 51 results.

No existing index covers `(entity_status, last_update_date) WHERE deleted_at IS NULL`:

- `idx_lei_records_inactive_name` — `(legal_name)`: covers only inactive + name, not date sorting
- `idx_lei_records_status_deleted_name` — `(status, legal_name)`: wrong sort column

## Fix — Migration 072

```sql
CREATE INDEX idx_lei_records_status_last_update_active
ON lei_raw.lei_records (entity_status, last_update_date DESC)
WHERE (deleted_at IS NULL);
```

- **Column 1 (`entity_status`)** — filters to requested status immediately
- **Column 2 (`last_update_date DESC`)** — index entries pre-sorted, no sort step
- **Partial predicate** — excludes soft-deleted rows

## Result

| Metric | Before | After |
|--------|--------|-------|
| Rows removed by filter | 4 652 | 0 |
| Buffer reads | 4 733 | 53 |
| Planning time | 474 ms | 32.9 ms |
| Execution time | 9.8 ms | 1.15 ms |
| App-reported time | ~533 ms | ~35 ms |

**15x improvement.** Applied live to `axiom_main`.

## Checklist

- [x] Migration has matching `.down.sql`
- [x] Applied and verified on `axiom_main`
- [x] No functional behaviour changes
