### PR TITLE
docs(workflow): harden PR thread reply flow across gh versions

### DIFF
--- a/.github/instructions/copilot-pr-comment-tracking.instructions.md
+++ b/.github/instructions/copilot-pr-comment-tracking.instructions.md
@@ -131,7 +131,7 @@ Set-Content -Path $bodyPath -Value "✅ **RESOLVED**: [Your resolution message]"
 
 Get-Content /tmp/copilot_comment_ids.txt | ForEach-Object {
   $commentId = $_.Trim()
-  gh pr comment 261 --reply-to "$commentId" --body-file "$bodyPath"
+  gh api repos/techie2000/axiom/pulls/261/comments/$commentId/replies -X POST -F "body=@$bodyPath"
 }
 ```
 
@@ -256,7 +256,7 @@ Set-Content -Path $replyPath -Value @'
 
 **Validation**: Tests pass, behavior maintained
 '@ -Encoding utf8
-gh pr comment 261 --reply-to 3045230708 --body-file "$replyPath"
+gh api repos/techie2000/axiom/pulls/261/comments/3045230708/replies -X POST -F "body=@$replyPath"
 
 # Reply to comment 3045230751
 Set-Content -Path $replyPath -Value @'
@@ -268,7 +268,7 @@ Set-Content -Path $replyPath -Value @'
 
 **Validation**: Tests pass, audit consistency verified
 '@ -Encoding utf8
-gh pr comment 261 --reply-to 3045230751 --body-file "$replyPath"
+gh api repos/techie2000/axiom/pulls/261/comments/3045230751/replies -X POST -F "body=@$replyPath"
 ```
 
 ### Step 4: Verify All Replied
@@ -313,7 +313,7 @@ gh api repos/techie2000/axiom/pulls/261/comments/$COMMENT_ID \
   --jq '{id: .id, path: .path, line: .line, preview: .body[0:80]}'
 
 # Review output before posting reply
-gh pr comment 261 --reply-to $COMMENT_ID --body "[Your reply]"
+gh api repos/techie2000/axiom/pulls/261/comments/$COMMENT_ID/replies -X POST -f body='[Your reply]'
 ```
 
 ### Mistake 3: Missing Comments in Pagination

--- a/.github/instructions/copilot-pr-comment-tracking.instructions.md
+++ b/.github/instructions/copilot-pr-comment-tracking.instructions.md
@@ -50,27 +50,27 @@ gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
 Use this in your session memory or as inline comments during work:
 
 ```markdown
-## PR #261 Copilot Feedback Tracking
+## PR #{pr_number} Copilot Feedback Tracking
 
 ### Transaction Safety Issues
-- **Comment ID 3045230708** (Line 473, currencies.go)
+- **Comment ID {comment_id_1}** (Line 473, currencies.go)
   - Status: ✅ FIXED
   - Fix: Moved audit write after UPDATE
   - Post: Posted as reply 14:32 UTC
   
-- **Comment ID 3045230751** (Line 217, continents.go)
+- **Comment ID {comment_id_2}** (Line 217, continents.go)
   - Status: ✅ FIXED
   - Fix: Moved audit write after DELETE
   - Post: Posted as reply 14:35 UTC
 
 ### Performance Issues
-- **Comment ID 3045230772** (Line 662, code_mappings.go)
+- **Comment ID {comment_id_3}** (Line 662, code_mappings.go)
   - Status: ✅ FIXED
   - Fix: Batch-load instead of per-row SELECT
   - Post: Posted as reply 14:38 UTC
 
 ### Test Coverage
-- **Comment ID 3045230787** (Line 204)
+- **Comment ID {comment_id_4}** (Line 204)
   - Status: ⏳ DEFERRED
   - Reason: Requires test DB infrastructure
   - Follow-up: Next PR
@@ -81,27 +81,27 @@ Use this in your session memory or as inline comments during work:
 
 ```json
 {
-  "pr_number": 261,
+  "pr_number": "{pr_number}",
   "copilot_comments": [
     {
-      "id": 3045230708,
+      "id": "{comment_id_1}",
       "file": "backend/internal/service/masterdata_service.go",
       "line": 473,
       "category": "Transaction Safety",
       "issue": "Audit write before UPDATE",
       "status": "resolved",
-      "fix_commit": "5340e2c",
+      "fix_commit": "{fix_commit_sha}",
       "reply_posted": true,
       "reply_time": "2026-04-07T14:32:00Z"
     },
     {
-      "id": 3045230751,
+      "id": "{comment_id_2}",
       "file": "backend/internal/service/masterdata_service.go",
       "line": 217,
       "category": "Transaction Safety",
       "issue": "Audit write before DELETE",
       "status": "resolved",
-      "fix_commit": "5340e2c",
+      "fix_commit": "{fix_commit_sha}",
       "reply_posted": true,
       "reply_time": "2026-04-07T14:35:00Z"
     }
@@ -118,7 +118,7 @@ Use this in your session memory or as inline comments during work:
 **Setup - Get all comment IDs first:**
 
 ```bash
-gh api repos/techie2000/axiom/pulls/261/comments \
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
   --jq '.[] | select(.user.login == "Copilot") | .id' \
   > /tmp/copilot_comment_ids.txt
 ```
@@ -131,7 +131,7 @@ Set-Content -Path $bodyPath -Value "✅ **RESOLVED**: [Your resolution message]"
 
 Get-Content /tmp/copilot_comment_ids.txt | ForEach-Object {
   $commentId = $_.Trim()
-  gh api repos/techie2000/axiom/pulls/261/comments/$commentId/replies -X POST -F "body=@$bodyPath"
+  gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/$commentId/replies -X POST -F "body=@$bodyPath"
 }
 ```
 
@@ -139,7 +139,7 @@ Get-Content /tmp/copilot_comment_ids.txt | ForEach-Object {
 
 ```bash
 # Get all comments organized by file and category
-gh api repos/techie2000/axiom/pulls/261/comments \
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
   --jq 'group_by(.path) | map({
     file: .[0].path,
     count: length,
@@ -154,17 +154,17 @@ gh api repos/techie2000/axiom/pulls/261/comments \
 ```text
 TRANSACTION SAFETY (3 comments)
 ├─ masterdata_service.go (3)
-│  ├─ Comment 3045230708 - Line 473
-│  ├─ Comment 3045230751 - Line 217
-│  └─ Comment 3046789012 - Line 345
+│  ├─ Comment {comment_id_1} - Line 473
+│  ├─ Comment {comment_id_2} - Line 217
+│  └─ Comment {comment_id_5} - Line 345
 │
 PERFORMANCE (1 comment)
 ├─ masterdata_service.go (1)
-│  └─ Comment 3045230772 - Line 662
+│  └─ Comment {comment_id_3} - Line 662
 │
 TEST COVERAGE (1 comment)
 ├─ masterdata_service_test.go (1)
-│  └─ Comment 3045230787 - Line 204
+│  └─ Comment {comment_id_4} - Line 204
 │
 MARKDOWN LINT (3 comments) - N/A
 ├─ frontend-ui.instructions.md
@@ -176,13 +176,13 @@ MARKDOWN LINT (3 comments) - N/A
 
 ```text
 ✅ RESOLVED (4)
-├─ 3045230708 - Transaction Safety - currencies.go
-├─ 3045230751 - Transaction Safety - continents.go
-├─ 3045230772 - Performance - code_mappings.go
-└─ 3046789012 - Code Quality - service.go
+├─ {comment_id_1} - Transaction Safety - currencies.go
+├─ {comment_id_2} - Transaction Safety - continents.go
+├─ {comment_id_3} - Performance - code_mappings.go
+└─ {comment_id_5} - Code Quality - service.go
 
 ⏳ DEFERRED (1)
-└─ 3045230787 - Test Coverage - [Requires test DB setup]
+└─ {comment_id_4} - Test Coverage - [Requires test DB setup]
 
 ⚪ N/A (3)
 ├─ [Markdown files removed]
@@ -192,10 +192,10 @@ MARKDOWN LINT (3 comments) - N/A
 
 ```text
 REPLIED (4)
-├─ 3045230708 ✓ replied at 14:32
-├─ 3045230751 ✓ replied at 14:35
-├─ 3045230772 ✓ replied at 14:38
-└─ 3045230787 ✓ replied at 14:50 (deferred note)
+├─ {comment_id_1} ✓ replied at 14:32
+├─ {comment_id_2} ✓ replied at 14:35
+├─ {comment_id_3} ✓ replied at 14:38
+└─ {comment_id_4} ✓ replied at 14:50 (deferred note)
 
 NOT REPLIED (0)
 
@@ -209,7 +209,7 @@ SUMMARY (1)
 
 ```bash
 # Extract all Copilot comment IDs and save to file
-gh api repos/techie2000/axiom/pulls/261/comments \
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
   --jq '.[] | select(.user.login == "Copilot") | "\(.id),\(.path),\(.line),\(.body[0:50])"' \
   > comments_to_address.csv
 
@@ -222,18 +222,18 @@ gh api repos/techie2000/axiom/pulls/261/comments \
 ## Addressing Comments - Session 1
 
 ### Working On:
-- [ ] Comment 3045230708 (Line 473) - **IN PROGRESS**
+- [ ] Comment {comment_id_1} (Line 473) - **IN PROGRESS**
   - File: backend/internal/service/masterdata_service.go
   - Issue: Audit write before UPDATE
   - Fix: Reordering audit call
   
 ### Completed:
-- [x] Comment 3045230708 (Line 473)
+- [x] Comment {comment_id_1} (Line 473)
   - Fix commit: abc1234
   - Reply posted: Yes
   
 ### To Address Later:
-- [ ] Comment 3045230787 (Line 204)
+- [ ] Comment {comment_id_4} (Line 204)
   - Reason: Needs test DB infrastructure
   - When: Next sprint
 ```
@@ -245,7 +245,7 @@ gh api repos/techie2000/axiom/pulls/261/comments \
 
 $replyPath = Join-Path $env:TEMP "copilot-reply.md"
 
-# Reply to comment 3045230708
+# Reply to comment {comment_id_1}
 Set-Content -Path $replyPath -Value @'
 ✅ **RESOLVED**: Reordered audit to after UPDATE
 
@@ -256,9 +256,9 @@ Set-Content -Path $replyPath -Value @'
 
 **Validation**: Tests pass, behavior maintained
 '@ -Encoding utf8
-gh api repos/techie2000/axiom/pulls/261/comments/3045230708/replies -X POST -F "body=@$replyPath"
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id_1}/replies -X POST -F "body=@$replyPath"
 
-# Reply to comment 3045230751
+# Reply to comment {comment_id_2}
 Set-Content -Path $replyPath -Value @'
 ✅ **RESOLVED**: Reordered audit to after DELETE
 
@@ -268,14 +268,14 @@ Set-Content -Path $replyPath -Value @'
 
 **Validation**: Tests pass, audit consistency verified
 '@ -Encoding utf8
-gh api repos/techie2000/axiom/pulls/261/comments/3045230751/replies -X POST -F "body=@$replyPath"
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id_2}/replies -X POST -F "body=@$replyPath"
 ```
 
 ### Step 4: Verify All Replied
 
 ```bash
 # Check which comments you've replied to
-gh api repos/techie2000/axiom/pulls/261/comments \
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
   --jq '[.[] | select(.user.login == "Copilot") | {id: .id, repliedCount: (.. | objects | select(.user.login != "Copilot") | .user.login) | length}]'
 ```
 
@@ -287,7 +287,7 @@ gh api repos/techie2000/axiom/pulls/261/comments \
 
 ```bash
 # Save original count
-ORIGINAL_COUNT=$(gh api repos/techie2000/axiom/pulls/261/comments \
+ORIGINAL_COUNT=$(gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
   --jq '[.[] | select(.user.login == "Copilot")] | length')
 
 echo "Total Copilot comments to address: $ORIGINAL_COUNT"
@@ -308,12 +308,12 @@ fi
 
 ```bash
 # Always verify comment ID before posting
-COMMENT_ID="3045230708"
-gh api repos/techie2000/axiom/pulls/261/comments/$COMMENT_ID \
+COMMENT_ID="{comment_id}"
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/$COMMENT_ID \
   --jq '{id: .id, path: .path, line: .line, preview: .body[0:80]}'
 
 # Review output before posting reply
-gh api repos/techie2000/axiom/pulls/261/comments/$COMMENT_ID/replies -X POST -f body='[Your reply]'
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/$COMMENT_ID/replies -X POST -f body='[Your reply]'
 ```
 
 ### Mistake 3: Missing Comments in Pagination
@@ -323,7 +323,7 @@ gh api repos/techie2000/axiom/pulls/261/comments/$COMMENT_ID/replies -X POST -f 
 ```bash
 # GitHub API paginates at 30 items by default
 # Use --paginate to get all
-gh api repos/techie2000/axiom/pulls/261/comments --paginate \
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --paginate \
   --jq '[.[] | select(.user.login == "Copilot") | .id]' \
   > all_copilot_ids.txt
 
@@ -336,11 +336,11 @@ wc -l all_copilot_ids.txt  # Verify you got all
 
 ```bash
 # Create a tracking snapshot
-gh api repos/techie2000/axiom/pulls/261/comments --paginate \
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --paginate \
   --jq '.[] | select(.user.login == "Copilot") | {id: .id, file: .path, line: .line, status: "pending"}' \
-  > pr261_copilot_tracking.json
+  > pr${pr_number}_copilot_tracking.json
 
-echo "Tracking created: $(jq 'length' pr261_copilot_tracking.json) comments"
+echo "Tracking created: $(jq 'length' pr${pr_number}_copilot_tracking.json) comments"
 ```
 
 ### While Fixing
@@ -350,14 +350,14 @@ echo "Tracking created: $(jq 'length' pr261_copilot_tracking.json) comments"
 # (Manual or via script)
 
 # Check progress
-jq '[.[] | select(.status == "resolved") | .id]' pr261_copilot_tracking.json | wc -l
+jq '[.[] | select(.status == "resolved") | .id]' pr${pr_number}_copilot_tracking.json | wc -l
 ```
 
 ### After All Fixes
 
 ```bash
 # Verify all comments addressed
-jq '.[] | select(.status != "resolved" and .status != "deferred" and .status != "n/a")' pr261_copilot_tracking.json
+jq '.[] | select(.status != "resolved" and .status != "deferred" and .status != "n/a")' pr${pr_number}_copilot_tracking.json
 
 # Should return empty if all handled
 ```
@@ -371,8 +371,8 @@ jq '.[] | select(.status != "resolved" and .status != "deferred" and .status != 
 # track-copilot-comments.sh
 
 PR_NUMBER=$1
-OWNER="techie2000"
-REPO="axiom"
+OWNER="<owner>"
+REPO="<repo>"
 
 # Fetch all Copilot comments
 echo "Fetching all Copilot comments..."
@@ -395,7 +395,7 @@ Usage:
 
 ```bash
 chmod +x track-copilot-comments.sh
-./track-copilot-comments.sh 261
+./track-copilot-comments.sh <pr_number>
 ```
 
 ## Troubleshooting Comment ID Issues
@@ -404,7 +404,7 @@ chmod +x track-copilot-comments.sh
 
 ```bash
 # Verify comment still exists
-gh api repos/techie2000/axiom/pulls/261/comments/3045230708
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}
 
 # If deleted, it won't exist but that's OK - note it as removed
 ```
@@ -413,7 +413,7 @@ gh api repos/techie2000/axiom/pulls/261/comments/3045230708
 
 ```bash
 # Ensure format is correct (must be numeric ID, not thread ID)
-gh api repos/techie2000/axiom/pulls/261/comments \
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
   --jq '.[] | select(.user.login == "Copilot") | .id'
 
 # Use numeric ID from above, not node_id
@@ -423,7 +423,7 @@ gh api repos/techie2000/axiom/pulls/261/comments \
 
 ```bash
 # GitHub doesn't prevent duplicate replies, but you can check:
-gh api repos/techie2000/axiom/pulls/261/comments/3045230708/replies \
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
   --jq '.[] | {author: .user.login, created: .created_at}'
 ```
 

--- a/.github/instructions/copilot-pr-comment-tracking.instructions.md
+++ b/.github/instructions/copilot-pr-comment-tracking.instructions.md
@@ -131,7 +131,7 @@ Set-Content -Path $bodyPath -Value "✅ **RESOLVED**: [Your resolution message]"
 
 Get-Content /tmp/copilot_comment_ids.txt | ForEach-Object {
   $commentId = $_.Trim()
-  gh api repos/techie2000/axiom/pulls/comments/$commentId/replies -X POST -F "body=@$bodyPath"
+  gh api repos/techie2000/axiom/pulls/261/comments/$commentId/replies -X POST -F "body=@$bodyPath"
 }
 ```
 
@@ -256,7 +256,7 @@ Set-Content -Path $replyPath -Value @'
 
 **Validation**: Tests pass, behavior maintained
 '@ -Encoding utf8
-gh api repos/techie2000/axiom/pulls/comments/3045230708/replies -X POST -F "body=@$replyPath"
+gh api repos/techie2000/axiom/pulls/261/comments/3045230708/replies -X POST -F "body=@$replyPath"
 
 # Reply to comment 3045230751
 Set-Content -Path $replyPath -Value @'
@@ -268,7 +268,7 @@ Set-Content -Path $replyPath -Value @'
 
 **Validation**: Tests pass, audit consistency verified
 '@ -Encoding utf8
-gh api repos/techie2000/axiom/pulls/comments/3045230751/replies -X POST -F "body=@$replyPath"
+gh api repos/techie2000/axiom/pulls/261/comments/3045230751/replies -X POST -F "body=@$replyPath"
 ```
 
 ### Step 4: Verify All Replied
@@ -313,7 +313,7 @@ gh api repos/techie2000/axiom/pulls/261/comments/$COMMENT_ID \
   --jq '{id: .id, path: .path, line: .line, preview: .body[0:80]}'
 
 # Review output before posting reply
-gh api repos/techie2000/axiom/pulls/comments/$COMMENT_ID/replies -X POST -f body='[Your reply]'
+gh api repos/techie2000/axiom/pulls/261/comments/$COMMENT_ID/replies -X POST -f body='[Your reply]'
 ```
 
 ### Mistake 3: Missing Comments in Pagination
@@ -423,7 +423,7 @@ gh api repos/techie2000/axiom/pulls/261/comments \
 
 ```bash
 # GitHub doesn't prevent duplicate replies, but you can check:
-gh api repos/techie2000/axiom/pulls/comments/3045230708/replies \
+gh api repos/techie2000/axiom/pulls/261/comments/3045230708/replies \
   --jq '.[] | {author: .user.login, created: .created_at}'
 ```
 

--- a/.github/instructions/copilot-pr-comment-tracking.instructions.md
+++ b/.github/instructions/copilot-pr-comment-tracking.instructions.md
@@ -131,7 +131,7 @@ Set-Content -Path $bodyPath -Value "✅ **RESOLVED**: [Your resolution message]"
 
 Get-Content /tmp/copilot_comment_ids.txt | ForEach-Object {
   $commentId = $_.Trim()
-  gh api repos/techie2000/axiom/pulls/261/comments/$commentId/replies -X POST -F "body=@$bodyPath"
+  gh api repos/techie2000/axiom/pulls/comments/$commentId/replies -X POST -F "body=@$bodyPath"
 }
 ```
 
@@ -256,7 +256,7 @@ Set-Content -Path $replyPath -Value @'
 
 **Validation**: Tests pass, behavior maintained
 '@ -Encoding utf8
-gh api repos/techie2000/axiom/pulls/261/comments/3045230708/replies -X POST -F "body=@$replyPath"
+gh api repos/techie2000/axiom/pulls/comments/3045230708/replies -X POST -F "body=@$replyPath"
 
 # Reply to comment 3045230751
 Set-Content -Path $replyPath -Value @'
@@ -268,7 +268,7 @@ Set-Content -Path $replyPath -Value @'
 
 **Validation**: Tests pass, audit consistency verified
 '@ -Encoding utf8
-gh api repos/techie2000/axiom/pulls/261/comments/3045230751/replies -X POST -F "body=@$replyPath"
+gh api repos/techie2000/axiom/pulls/comments/3045230751/replies -X POST -F "body=@$replyPath"
 ```
 
 ### Step 4: Verify All Replied
@@ -313,7 +313,7 @@ gh api repos/techie2000/axiom/pulls/261/comments/$COMMENT_ID \
   --jq '{id: .id, path: .path, line: .line, preview: .body[0:80]}'
 
 # Review output before posting reply
-gh api repos/techie2000/axiom/pulls/261/comments/$COMMENT_ID/replies -X POST -f body='[Your reply]'
+gh api repos/techie2000/axiom/pulls/comments/$COMMENT_ID/replies -X POST -f body='[Your reply]'
 ```
 
 ### Mistake 3: Missing Comments in Pagination
@@ -423,7 +423,7 @@ gh api repos/techie2000/axiom/pulls/261/comments \
 
 ```bash
 # GitHub doesn't prevent duplicate replies, but you can check:
-gh api repos/techie2000/axiom/pulls/261/comments/3045230708/replies \
+gh api repos/techie2000/axiom/pulls/comments/3045230708/replies \
   --jq '.[] | {author: .user.login, created: .created_at}'
 ```
 

--- a/.github/instructions/copilot-pr-feedback-resolution.instructions.md
+++ b/.github/instructions/copilot-pr-feedback-resolution.instructions.md
@@ -92,12 +92,12 @@ Set-Content -Path $bodyPath -Value $body -Encoding utf8
 # - If `gh pr comment --help` includes `--reply-to`, that command is usable.
 # - Otherwise (or by default), use the API endpoint below.
 
-gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies `
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies `
   -X POST `
   -F "body=@$bodyPath"
 
 # Verify reply exists on thread
-gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies --jq '.[-1].body'
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies --jq '.[-1].body'
 ```
 
 ### Comment Template by Issue Type
@@ -268,7 +268,7 @@ If any comments are deferred for later:
 ### Comment in Correct Scope
 
 - **Individual resolutions**: Reply directly to the Copilot comment thread using
-  `POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/replies`
+  `POST /repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies`
 - **Summary comment**: Post as standalone comment on the PR using `gh pr comment`
 - **Issue updates**: Post concise mirrored updates on linked underlying issues using `gh issue comment`
 - **Never duplicate**: Don't post the same resolution in multiple places

--- a/.github/instructions/copilot-pr-feedback-resolution.instructions.md
+++ b/.github/instructions/copilot-pr-feedback-resolution.instructions.md
@@ -92,12 +92,12 @@ Set-Content -Path $bodyPath -Value $body -Encoding utf8
 # - If `gh pr comment --help` includes `--reply-to`, that command is usable.
 # - Otherwise (or by default), use the API endpoint below.
 
-gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies `
+gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies `
   -X POST `
   -F "body=@$bodyPath"
 
 # Verify reply exists on thread
-gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies --jq '.[-1].body'
+gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies --jq '.[-1].body'
 ```
 
 ### Comment Template by Issue Type
@@ -268,7 +268,7 @@ If any comments are deferred for later:
 ### Comment in Correct Scope
 
 - **Individual resolutions**: Reply directly to the Copilot comment thread using
-  `POST /repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies`
+  `POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/replies`
 - **Summary comment**: Post as standalone comment on the PR using `gh pr comment`
 - **Issue updates**: Post concise mirrored updates on linked underlying issues using `gh issue comment`
 - **Never duplicate**: Don't post the same resolution in multiple places

--- a/.github/instructions/copilot-pr-feedback-resolution.instructions.md
+++ b/.github/instructions/copilot-pr-feedback-resolution.instructions.md
@@ -88,20 +88,16 @@ $body = @'
 
 Set-Content -Path $bodyPath -Value $body -Encoding utf8
 
-# Prefer the safe helper to post + verify body fidelity and receive a stable URL.
-$commentUrl = pwsh ./scripts/post-gh-comment-safe.ps1 `
-  -Repo "{owner}/{repo}" `
-  -TargetType pr `
-  -PrNumber 261 `
-  -BodyFile "$bodyPath"
+# Capability check:
+# - If `gh pr comment --help` includes `--reply-to`, that command is usable.
+# - Otherwise (or by default), use the API endpoint below.
 
-Write-Host "Posted resolution comment: $commentUrl"
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies `
+  -X POST `
+  -F "body=@$bodyPath"
 
-# If posting a reply with gh directly, verify with issues/comments endpoint
-# because gh pr comment --reply-to creates an issue comment in the PR timeline.
-# $replyUrl = gh pr comment 261 --reply-to {comment_id} --body-file "$bodyPath"
-# $newCommentId = [regex]::Match(($replyUrl | Select-Object -Last 1), 'issuecomment-(\d+)$').Groups[1].Value
-# gh api repos/{owner}/{repo}/issues/comments/$newCommentId --jq .body
+# Verify reply exists on thread
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies --jq '.[-1].body'
 ```
 
 ### Comment Template by Issue Type
@@ -271,7 +267,8 @@ If any comments are deferred for later:
 
 ### Comment in Correct Scope
 
-- **Individual resolutions**: Reply directly to the Copilot comment thread using `--reply-to {comment_id}`
+- **Individual resolutions**: Reply directly to the Copilot comment thread using
+  `POST /repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies`
 - **Summary comment**: Post as standalone comment on the PR using `gh pr comment`
 - **Issue updates**: Post concise mirrored updates on linked underlying issues using `gh issue comment`
 - **Never duplicate**: Don't post the same resolution in multiple places
@@ -289,7 +286,7 @@ If you cannot locate a Copilot comment ID:
 
 - Use `gh api repos/{owner}/{repo}/pulls/{pr}/comments` to list all comments
 - Filter by `.user.login == "Copilot"`
-- Extract the `.id` for the reply-to target
+- Extract the `.id` for the `pulls/comments/{id}/replies` target
 
 ## Best Practices
 

--- a/.github/instructions/pr-merge-cleanup.instructions.md
+++ b/.github/instructions/pr-merge-cleanup.instructions.md
@@ -95,49 +95,49 @@ git fetch origin --prune
 ### Single PR Merge
 
 **User announces:**
-> "PR #220 merged"
+> "PR #{PR_NUMBER} merged"
 
 **Cleanup:**
 
 ```bash
-gh api repos/techie2000/axiom/pulls/220 --jq '{merged}'
+gh api repos/techie2000/axiom/pulls/{PR_NUMBER} --jq '{merged}'
 # Verify: "merged": true
 
-git branch -D pr-220  # or branch tracking the PR
+git branch -D pr-{PR_NUMBER}  # or branch tracking the PR
 git fetch origin --prune
 ```
 
 ### Multiple PRs Merged
 
 **User announces:**
-> "PRs #155, #220, #272 merged"
+> "PRs #{PR_1}, #{PR_2}, #{PR_3} merged"
 
 **Cleanup:**
 
 ```powershell
-foreach ($pr in @(155, 220, 272)) {
+foreach ($pr in @({PR_1}, {PR_2}, {PR_3})) {
     gh api repos/techie2000/axiom/pulls/$pr --jq '{number, merged}'
 }
 # Verify all show "merged": true
 
-git branch -D pr-155 pr-220 pr-272
+git branch -D pr-{PR_1} pr-{PR_2} pr-{PR_3}
 git fetch origin --prune
 ```
 
 ### PR with Associated Worktrees
 
 **User announces:**
-> "PR #352 for LEI status badge merged"
+> "PR #{PR_NUMBER} for LEI status badge merged"
 
 **Cleanup:**
 
 ```bash
 # Confirm merge
-gh api repos/techie2000/axiom/pulls/352 --jq '{merged}'
+gh api repos/techie2000/axiom/pulls/{PR_NUMBER} --jq '{merged}'
 
 # Remove worktrees
 git worktree list | grep -i "lei.*badge"
-git worktree remove worktrees/issue-352-lei-status-badge --force
+git worktree remove worktrees/issue-{PR_NUMBER}-lei-status-badge --force
 
 # Delete branches
 git branch -D feat/lei-status-badge fix/lei-status-badge-copilot-feedback

--- a/.github/skills/address-pr-comments/SKILL.md
+++ b/.github/skills/address-pr-comments/SKILL.md
@@ -97,7 +97,7 @@ Maintain a list of comment IDs and their resolution status:
 
 ```bash
 # Preferred, gh-version-independent method:
-gh api repos/<owner>/<repo>/pulls/<pr-number>/comments/<comment-id>/replies \
+gh api repos/<owner>/<repo>/pulls/comments/<comment-id>/replies \
    -X POST \
    -F "body=@/path/to/resolution.md"
 ```
@@ -182,7 +182,7 @@ For inline thread replies, use GitHub API `pulls/comments/{comment_id}/replies`.
 
 ```powershell
 $replyPath = "path/to/resolution.md"
-gh api repos/<owner>/<repo>/pulls/<pr-number>/comments/<comment-id>/replies `
+gh api repos/<owner>/<repo>/pulls/comments/<comment-id>/replies `
    -X POST `
    -F "body=@$replyPath"
 ```

--- a/.github/skills/address-pr-comments/SKILL.md
+++ b/.github/skills/address-pr-comments/SKILL.md
@@ -96,8 +96,17 @@ Maintain a list of comment IDs and their resolution status:
 **DO NOT ask for confirmation.** For each resolved comment, post a reply to that thread:
 
 ```bash
-gh pr comment <pr-number> --reply-to <comment-id> --body-file "/path/to/resolution.md"
+# Preferred, gh-version-independent method:
+gh api repos/<owner>/<repo>/pulls/<pr-number>/comments/<comment-id>/replies \
+   -X POST \
+   -F "body=@/path/to/resolution.md"
 ```
+
+Compatibility gate:
+
+- First run `gh pr comment --help`.
+- Only use `gh pr comment --reply-to ...` if `--reply-to` appears in help output.
+- If `--reply-to` is not supported, use the API method above.
 
 #### Resolution Comment Template by Type
 
@@ -168,16 +177,14 @@ gh pr comment <pr-number> --reply-to <comment-id> --body-file "/path/to/resoluti
 **Validation**: `make docs-check`, linters pass
 ```
 
-Use the safe comment helper if available to verify rendered body before posting.
-For Bash shells, use the `gh pr comment --reply-to` command shown above.
+Use the safe comment helper for top-level PR/issue comments only.
+For inline thread replies, use GitHub API `pulls/comments/{comment_id}/replies`.
 
 ```powershell
-pwsh ./scripts/post-gh-comment-safe.ps1 `
-  -Repo "techie2000/axiom" `
-  -TargetType pr `
-  -PrNumber <pr-number> `
-  -ReplyToId <comment-id> `
-  -BodyFile "path/to/resolution.md"
+$replyPath = "path/to/resolution.md"
+gh api repos/<owner>/<repo>/pulls/<pr-number>/comments/<comment-id>/replies `
+   -X POST `
+   -F "body=@$replyPath"
 ```
 
 ### 8. Push and Verify (Automatic)

--- a/.github/skills/address-pr-comments/SKILL.md
+++ b/.github/skills/address-pr-comments/SKILL.md
@@ -97,7 +97,7 @@ Maintain a list of comment IDs and their resolution status:
 
 ```bash
 # Preferred, gh-version-independent method:
-gh api repos/<owner>/<repo>/pulls/comments/<comment-id>/replies \
+gh api repos/<owner>/<repo>/pulls/<pr-number>/comments/<comment-id>/replies \
    -X POST \
    -F "body=@/path/to/resolution.md"
 ```
@@ -182,7 +182,7 @@ For inline thread replies, use GitHub API `pulls/comments/{comment_id}/replies`.
 
 ```powershell
 $replyPath = "path/to/resolution.md"
-gh api repos/<owner>/<repo>/pulls/comments/<comment-id>/replies `
+gh api repos/<owner>/<repo>/pulls/<pr-number>/comments/<comment-id>/replies `
    -X POST `
    -F "body=@$replyPath"
 ```

--- a/.github/skills/address-pr-comments/SKILL.md
+++ b/.github/skills/address-pr-comments/SKILL.md
@@ -82,13 +82,13 @@ Maintain a list of comment IDs and their resolution status:
 
 ```text
 ✅ RESOLVED (4)
-├─ 3045230708 - Transaction Safety - [description]
-├─ 3045230751 - Transaction Safety - [description]
-├─ 3045230772 - Performance - [description]
-└─ 3046789012 - Code Quality - [description]
+├─ {comment_id_1} - Transaction Safety - [description]
+├─ {comment_id_2} - Transaction Safety - [description]
+├─ {comment_id_3} - Performance - [description]
+└─ {comment_id_4} - Code Quality - [description]
 
 ⏳ DEFERRED (1)
-└─ 3045230787 - Test Coverage - [Reason: Requires test DB setup]
+└─ {comment_id_5} - Test Coverage - [Reason: Requires test DB setup]
 ```
 
 ### 7. Post Individual Resolution Comments (Automatic)


### PR DESCRIPTION
Improve PR feedback resolution guidance to work across GitHub CLI versions.

## Problem

Some environments do not support `gh pr comment --reply-to`, causing reply-posting failures and wasted iteration time when resolving Copilot threads.

## Changes

- Add a compatibility gate to check for `--reply-to` support
- Use the API reply endpoint as the reliable default:
  - `POST /repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies`
- Align skill and instruction examples to the API fallback workflow
- Clarify scope of `scripts/post-gh-comment-safe.ps1` (top-level PR/issue comments)

## Impact

- Prevents recurring reply-posting failures on older gh versions
- Speeds up address-pr-comments execution
- Keeps PR thread resolution workflow deterministic
