### PR TITLE
fix: provisional LEI amendment fails when country field is blank

### DIFF
--- a/backend/internal/repository/provisional_lei_repository.go
+++ b/backend/internal/repository/provisional_lei_repository.go
@@ -138,7 +138,12 @@ func (r *provisionalLEIRepository) Update(record *domain.LEIRecord) error {
 	}
 	// Update only the fields that matter for provisional LEI records, not all fields.
 	// This prevents empty strings from being written to domain-typed columns like hq_address_country.
-	result := r.db.Table("lei_raw.lei_records").Where("id = ?", record.ID).Updates(map[string]interface{}{
+	result := r.db.Table("lei_raw.lei_records").Where("id = ?", record.ID).Updates(provisionalLEIUpdatePayload(record))
+	return result.Error
+}
+
+func provisionalLEIUpdatePayload(record *domain.LEIRecord) map[string]interface{} {
+	return map[string]interface{}{
 		"legal_name":            record.LegalName,
 		"legal_address_country": nullableString(record.LegalAddressCountry),
 		"legal_address_city":    record.LegalAddressCity,
@@ -148,8 +153,7 @@ func (r *provisionalLEIRepository) Update(record *domain.LEIRecord) error {
 		"notes":                 nullableString(record.Notes),
 		"updated_by":            record.UpdatedBy,
 		"last_update_date":      record.LastUpdateDate,
-	})
-	return result.Error
+	}
 }
 
 func (r *provisionalLEIRepository) FindByLEI(lei string) (*domain.LEIRecord, error) {

--- a/backend/internal/repository/provisional_lei_repository.go
+++ b/backend/internal/repository/provisional_lei_repository.go
@@ -140,9 +140,9 @@ func (r *provisionalLEIRepository) Update(record *domain.LEIRecord) error {
 	// This prevents empty strings from being written to domain-typed columns like hq_address_country.
 	result := r.db.Table("lei_raw.lei_records").Where("id = ?", record.ID).Updates(map[string]interface{}{
 		"legal_name":            record.LegalName,
-		"legal_address_country": record.LegalAddressCountry,
+		"legal_address_country": nullableString(record.LegalAddressCountry),
 		"legal_address_city":    record.LegalAddressCity,
-		"legal_jurisdiction":    record.LegalJurisdiction,
+		"legal_jurisdiction":    nullableString(record.LegalJurisdiction),
 		"entity_status":         record.EntityStatus,
 		"provisioning_source":   record.ProvisioningSource,
 		"notes":                 nullableString(record.Notes),

--- a/backend/internal/repository/provisional_lei_repository_test.go
+++ b/backend/internal/repository/provisional_lei_repository_test.go
@@ -83,6 +83,38 @@ func TestProvisionalLEIInsertPayload_ConvertsConstrainedEmptyStringsToNull(t *te
 	}
 }
 
+func TestProvisionalLEIUpdatePayload_ConvertsConstrainedEmptyStringsToNull(t *testing.T) {
+	t.Helper()
+
+	// Regression test: Verify UPDATE payload converts empty country/jurisdiction to NULL.
+	// Issue #546: Empty string for legal_address_country triggered domain constraint violation.
+	// Update path must wrap these fields with nullableString() just like Create path.
+	record := &domain.LEIRecord{
+		ID:                  uuid.New(),
+		LegalName:           "Test Update",
+		LegalAddressCountry: "", // Empty string should become NULL
+		LegalJurisdiction:   "", // Empty string should become NULL
+		LegalAddressCity:    "London",
+		EntityStatus:        "ACTIVE",
+		ProvisioningSource:  "update-test",
+	}
+
+	payload := provisionalLEIUpdatePayload(record)
+
+	// These fields should be nil (NULL in SQL) when source is empty string
+	constrainedFields := []string{"legal_address_country", "legal_jurisdiction"}
+	for _, key := range constrainedFields {
+		if payload[key] != nil {
+			t.Fatalf("expected %s to be nil for empty string (UPDATE path), got %v", key, payload[key])
+		}
+	}
+
+	// Non-constrained fields should still work normally
+	if payload["legal_address_city"] != record.LegalAddressCity {
+		t.Fatalf("payload legal_address_city = %v, want %v", payload["legal_address_city"], record.LegalAddressCity)
+	}
+}
+
 func TestValidateLEICode(t *testing.T) {
 	t.Helper()
 


### PR DESCRIPTION
Fixes #546

## What changed

In `backend/internal/repository/provisional_lei_repository.go`, the `Update()` method wrote `legal_address_country` and `legal_jurisdiction` as raw strings. After migration `000019_add_domain_types.up.sql` changed `legal_address_country` to the `country_code` domain type (`CHECK (VALUE ~ '^[A-Z]{2}$')`), sending an empty string caused a PostgreSQL constraint violation — preventing any provisional LEI amendment where country was left blank.

The `Create` path already used `nullableString()` for both fields (converting `""` to `NULL`). This PR applies the same wrapper to the `Update` map.

## Changes

- `legal_address_country`: `record.LegalAddressCountry` → `nullableString(record.LegalAddressCountry)`
- `legal_jurisdiction`: `record.LegalJurisdiction` → `nullableString(record.LegalJurisdiction)` _(no DB constraint but aligns with Create path)_

## Data impact

None. The PostgreSQL constraint rejected the bad write at the database level, so no invalid values could have been stored. No migration or cleanup script is required.

## Testing

- Create a provisional LEI with no country → verify succeeds (pre-existing behaviour, unchanged)
- Amend a provisional LEI leaving country blank → verify succeeds (was failing, now fixed)
- Amend a provisional LEI with a valid 2-letter country code → verify succeeds
