### PR TITLE
fix: backport PR576 Copilot fixes to main

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -20,6 +20,8 @@ POSTGRES_DB=axiom_dev
 POSTGRES_DATA_DIR=./data/dev/postgres
 
 # RabbitMQ Configuration
+# NOTE: Existing rabbitmq_data_dev volumes keep the originally initialized user/password.
+# If rotating credentials, run rabbitmqctl user updates or recreate the volume first.
 RABBITMQ_DEFAULT_USER=axiom_dev
 RABBITMQ_DEFAULT_PASS=axiom_dev_mq_pass
 

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # Usage:
 #   cp .env.example .env
 #   # Edit .env and set all values marked REQUIRED before running:
-#   docker compose up -d
+#   docker compose --env-file .env.main -f docker-compose.main.yml up -d
 #
 # ⚠️  NEVER commit .env (with real values) to version control.
 #     This file (.env.example) is safe to commit because it contains no real secrets.
@@ -14,6 +14,8 @@ DATABASE_PASSWORD=change-me-use-a-strong-password
 
 # RabbitMQ credentials (REQUIRED)
 # Set RABBITMQ_DEFAULT_USER/PASS and mirror them in the URL below.
+# For existing RabbitMQ volumes, rotate credentials explicitly (rabbitmqctl) or recreate
+# the volume before changing these values; env-only edits do not change existing users.
 RABBITMQ_DEFAULT_USER=axiom
 RABBITMQ_DEFAULT_PASS=change-me-use-a-strong-password
 RABBITMQ_URL=amqp://axiom:change-me-use-a-strong-password@rabbitmq:5672/

--- a/.env.main
+++ b/.env.main
@@ -22,6 +22,8 @@ POSTGRES_DB=axiom_main
 POSTGRES_DATA_DIR=./data/main/postgres
 
 # RabbitMQ Configuration
+# NOTE: Existing rabbitmq_data_main volumes keep the originally initialized user/password.
+# If rotating credentials, run rabbitmqctl user updates or recreate the volume first.
 RABBITMQ_DEFAULT_USER=axiom_main
 RABBITMQ_DEFAULT_PASS=axiom_main_mq_pass
 

--- a/.env.prod
+++ b/.env.prod
@@ -15,6 +15,8 @@ FRONTEND_PORT=33000
 # Database Configuration
 POSTGRES_USER=axiom
 # ⚠️  Set a strong, unique password before deploying. Never commit real credentials.
+# Existing initialized production volumes keep the original DB user password.
+# Rotate credentials with ALTER USER (or reset the volume) before changing this value.
 POSTGRES_PASSWORD=CHANGE_ME_REQUIRED
 POSTGRES_DB=axiom_prod
 
@@ -28,6 +30,8 @@ DATABASE_HOST=postgres
 DATABASE_PORT=5432
 DATABASE_USER=axiom
 # ⚠️  Must match POSTGRES_PASSWORD above.
+# Existing initialized production volumes keep the original DB user password.
+# Rotate credentials with ALTER USER (or reset the volume) before changing this value.
 DATABASE_PASSWORD=CHANGE_ME_REQUIRED
 DATABASE_LOGLEVEL=warn  # Options: silent, error, warn, info
 DATABASE_NAME=axiom_prod

--- a/.env.uat
+++ b/.env.uat
@@ -12,6 +12,8 @@ FRONTEND_PORT=23000
 # Database Configuration
 POSTGRES_USER=axiom
 # ⚠️  Set a strong, unique password before deploying. Never commit real credentials.
+# Existing initialized UAT volumes keep the original DB user password.
+# Rotate credentials with ALTER USER (or reset the volume) before changing this value.
 POSTGRES_PASSWORD=CHANGE_ME_REQUIRED
 POSTGRES_DB=axiom_uat
 
@@ -25,6 +27,8 @@ DATABASE_HOST=postgres
 DATABASE_PORT=5432
 DATABASE_USER=axiom
 # ⚠️  Must match POSTGRES_PASSWORD above.
+# Existing initialized UAT volumes keep the original DB user password.
+# Rotate credentials with ALTER USER (or reset the volume) before changing this value.
 DATABASE_PASSWORD=CHANGE_ME_REQUIRED
 DATABASE_LOGLEVEL=warn  # Options: silent, error, warn, info
 DATABASE_NAME=axiom_uat

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -777,21 +777,22 @@ When posting PR/issue comments, checklists, PR descriptions, or review summaries
 6. Keep comments actionable: include decisions, code/test results, or explicit next actions.
 7. Do not add non-actionable filler such as "checks are in progress" or equivalent queue/waiting notes in public comments.
 
-## EMU GitHub Review Comment Guardrail (REQUIRED)
+### EMU GitHub Review Comment Guardrail (REQUIRED)
 
 For this repository under Enterprise Managed User constraints, when handling PR review comment threads:
 
-**If running in cloud Copilot with MCP:**
+#### If Running In Cloud Copilot With MCP
 
 1. Try MCP GitHub PR review write/reply/resolve tools first (you may have better API permissions).
 2. If you hit 403 Unauthorized, immediately fall back to `gh` CLI method.
 3. Do not retry MCP after a 403 pattern in the same session.
 
-**If running in local VS Code (terminal):**
+#### If Running In Local VS Code (Terminal)
 
 1. Use `gh` CLI in terminal as the first and default path.
 2. Do not call MCP GitHub PR review write/reply/resolve tools (they consistently fail with 403 EMU).
-3. For thread replies, use `gh pr comment <pr> --repo <owner>/<repo> --reply-to <comment_id> --body-file <file>`.
+3. For thread replies, use:
+   - `gh api repos/<owner>/<repo>/pulls/<pr>/comments/<comment_id>/replies -X POST -F "body=@<file>"`
 4. After posting, verify with `gh pr view <pr> --repo <owner>/<repo> --comments`.
 5. If thread resolution is not available via CLI, resolve in GitHub UI and note that action.
 

--- a/.github/instructions/copilot-pr-feedback-resolution.instructions.md
+++ b/.github/instructions/copilot-pr-feedback-resolution.instructions.md
@@ -90,7 +90,7 @@ Set-Content -Path $bodyPath -Value $body -Encoding utf8
 
 # For LOCAL VS CODE (Terminal):
 # Use gh CLI as default (MCP tools consistently fail with 403 EMU).
-gh pr comment {pr_number} --repo {owner}/{repo} --reply-to {comment_id} --body-file "$bodyPath"
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies -X POST -F "body=@$bodyPath"
 
 # Verify your reply appears in PR comments.
 gh pr view {pr_number} --repo {owner}/{repo} --comments
@@ -268,7 +268,8 @@ If any comments are deferred for later:
 ### Comment in Correct Scope
 
 - **Individual resolutions**: Reply directly to the Copilot comment thread using:
-  - **Local VS Code**: `gh pr comment <pr> --repo <owner>/<repo> --reply-to <comment_id> --body-file <path>` (CLI-first)
+  - **Local VS Code**: `gh api repos/<owner>/<repo>/pulls/<pr>/comments/<comment_id>/replies -X POST -F "body=@<path>"`
+    (CLI-first)
   - **Cloud Copilot**: MCP tools (with gh CLI fallback if 403 Unauthorized)
 - **Summary comment**: Post as standalone comment on the PR using `gh pr comment`
 - **Issue updates**: Post concise mirrored updates on linked underlying issues using `gh issue comment`

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -60,14 +60,10 @@ func main() {
 	// Initialize logger
 	logger.Init(cfg.Log.Level)
 
-	// Configure Swagger metadata to use request origin instead of hard-coded localhost/http.
-	// This allows Swagger UI to work correctly behind reverse proxies, non-localhost hosts, and HTTPS.
-	// Empty Host means Swagger will use the request origin (the actual host of the incoming request).
-	// For Schemes, we keep both http and https since reverse proxies and load balancers may handle
-	// TLS termination upstream. This allows Swagger UI to work in both dev (http) and production (https).
-	// In reverse proxy scenarios, the actual scheme is determined by the request headers, not the configured schemes.
-	docs.SwaggerInfo.Host = ""
-	docs.SwaggerInfo.Schemes = []string{"http", "https"}
+	// Keep static defaults at startup and derive request-specific host/scheme in the
+	// Swagger route handler to support reverse proxies and non-localhost deployments.
+	docs.SwaggerInfo.Host = "localhost:8080"
+	docs.SwaggerInfo.Schemes = []string{"http"}
 
 	// Connect to database
 	db, err := connectDatabase(cfg)
@@ -334,7 +330,12 @@ func setupRouter(cfg *config.Config, h *handler.Handlers) *gin.Engine {
 	})
 
 	// Swagger documentation
-	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	swaggerHandler := ginSwagger.WrapHandler(swaggerFiles.Handler)
+	router.GET("/swagger/*any", func(c *gin.Context) {
+		docs.SwaggerInfo.Host = resolveSwaggerHost(c)
+		docs.SwaggerInfo.Schemes = []string{resolveSwaggerScheme(c)}
+		swaggerHandler(c)
+	})
 
 	// API v1 routes
 	v1 := router.Group("/api/v1")
@@ -521,4 +522,27 @@ func setupRouter(cfg *config.Config, h *handler.Handlers) *gin.Engine {
 	}
 
 	return router
+}
+
+func resolveSwaggerHost(c *gin.Context) string {
+	if forwardedHost := strings.TrimSpace(c.GetHeader("X-Forwarded-Host")); forwardedHost != "" {
+		return forwardedHost
+	}
+	if host := strings.TrimSpace(c.Request.Host); host != "" {
+		return host
+	}
+	return "localhost:8080"
+}
+
+func resolveSwaggerScheme(c *gin.Context) string {
+	if forwardedProto := strings.TrimSpace(c.GetHeader("X-Forwarded-Proto")); forwardedProto != "" {
+		if strings.EqualFold(forwardedProto, "https") {
+			return "https"
+		}
+		return "http"
+	}
+	if c.Request.TLS != nil {
+		return "https"
+	}
+	return "http"
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -121,6 +121,12 @@ func Load() (*Config, error) {
 	if err := viper.BindEnv("testing.playwrightuserpassword", "PLAYWRIGHT_USER_PASSWORD"); err != nil {
 		return nil, err
 	}
+	if err := viper.BindEnv("database.password", "DATABASE_PASSWORD"); err != nil {
+		return nil, err
+	}
+	if err := viper.BindEnv("jwt.secret", "JWT_SECRET"); err != nil {
+		return nil, err
+	}
 
 	var config Config
 	if err := viper.Unmarshal(&config); err != nil {
@@ -211,5 +217,11 @@ func validateSecrets(cfg *Config) error {
 
 func isSecretPlaceholder(value string) bool {
 	normalized := strings.ToUpper(strings.TrimSpace(value))
-	return normalized == "CHANGE_ME_REQUIRED"
+	if normalized == "" {
+		return false
+	}
+
+	return normalized == "CHANGE_ME_REQUIRED" ||
+		strings.HasPrefix(normalized, "CHANGE-ME") ||
+		strings.HasPrefix(normalized, "REPLACE-WITH")
 }

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -185,3 +185,40 @@ func TestValidateSecrets_PlaceholderPlaywrightPasswordRejectedWhenSeedEnabled(t 
 		t.Fatal("expected error when PLAYWRIGHT_USER_PASSWORD is placeholder and seed is enabled, got nil")
 	}
 }
+
+func TestValidateSecrets_PlaceholderPatternsRejected(t *testing.T) {
+	cases := []string{
+		"change-me-use-a-strong-password",
+		"replace-with-output-of-openssl-rand-hex-32",
+	}
+
+	for _, placeholder := range cases {
+		cfg := &Config{
+			JWT:      JWTConfig{Secret: placeholder},
+			Database: DatabaseConfig{Password: "somepass"},
+		}
+		if err := validateSecrets(cfg); err == nil {
+			t.Fatalf("expected error for placeholder pattern %q in JWT secret", placeholder)
+		}
+	}
+}
+
+func TestLoad_UsesEnvForRequiredSecretsWithoutDefaults(t *testing.T) {
+	resetViper()
+	defer resetViper()
+
+	t.Setenv("DATABASE_PASSWORD", "env-db-password")
+	t.Setenv("JWT_SECRET", "env-jwt-secret")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("expected Load to succeed with env-only required secrets, got: %v", err)
+	}
+
+	if cfg.Database.Password != "env-db-password" {
+		t.Fatalf("expected DATABASE_PASSWORD from env, got %q", cfg.Database.Password)
+	}
+	if cfg.JWT.Secret != "env-jwt-secret" {
+		t.Fatalf("expected JWT_SECRET from env, got %q", cfg.JWT.Secret)
+	}
+}

--- a/backend/internal/service/ui_translation_service.go
+++ b/backend/internal/service/ui_translation_service.go
@@ -63,7 +63,6 @@ func validateTranslationValueNesting(value string) error {
 		return nil
 	}
 
-	// Use pre-compiled translationNestingPattern for performance
 	matches := translationNestingPattern.FindAllStringSubmatch(value, -1)
 
 	for _, match := range matches {


### PR DESCRIPTION
## Summary
Backport of Copilot-thread fixes from PR #576 into `main`.

This backport includes:
- config env binding for required secret-only keys (`DATABASE_PASSWORD`, `JWT_SECRET`)
- stronger placeholder secret detection + config regression tests
- request-derived Swagger host/scheme handling
- markdown instruction fixes for portable review-thread reply commands and heading structure
- env-file credential rotation guidance for RabbitMQ/Postgres on existing volumes
- cleanup of redundant inline comment in UI translation service

## References
- Refs #577
- Backports fixes from #576

## Validation
- `cd backend && go test ./internal/config ./cmd/api ./internal/service`
